### PR TITLE
Allowing a heating- or cooling-only heat pump

### DIFF
--- a/docs/source/translation/cooling_system.rst
+++ b/docs/source/translation/cooling_system.rst
@@ -35,6 +35,13 @@ mapping.
    Prior to HEScore v2016 mini-split heat pumps were translated as ducted air-source heat pumps with ducts in conditioned space.
    With the addition of mini split heat pumps in HEScore v2016, they are now categorized appropriately.
 
+If a heat pump has a `FractionHeatlLoadServed` set to zero, the heat pump is
+assumed to provide only space cooling. If the heat pump is connected to the
+same distribution system as a separate heating system and serves the same
+portion of the house, the house will translate but fail in Home Energy Score
+because that configuration is not supported.
+
+
 .. _clg-sys:
 
 Cooling System

--- a/docs/source/translation/heating_system.rst
+++ b/docs/source/translation/heating_system.rst
@@ -37,6 +37,12 @@ The primary heating fuel is assumed to be electric.
    Prior to HEScore v2016 mini-split heat pumps were translated as ducted air-source heat pumps with ducts in conditioned space.
    With the addition of mini split heat pumps in HEScore v2016, they are now categorized appropriately.
 
+If a heat pump has a `FractionCoolLoadServed` set to zero, the heat pump is
+assumed to provide only space heating. If the heat pump is connected to the
+same distribution system as a separate cooling system and serves the same
+portion of the house, the house will translate but fail in Home Energy Score
+because that configuration is not supported.
+
 
 Heating System
 ==============

--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -10,6 +10,7 @@ import math
 import uuid
 from lxml import etree
 from collections import defaultdict, namedtuple
+from decimal import Decimal
 
 try:
     from collections import OrderedDict
@@ -1521,8 +1522,24 @@ class HPXMLtoHEScoreTranslator(object):
         # Get all heating systems
         hpxml_heating_systems = _get_dict_of_hpxml_elements_by_id('descendant::h:HVACPlant/h:HeatingSystem|descendant::h:HVACPlant/h:HeatPump')
 
+        # Remove heating systems that serve 0% of the heating load
+        for key, el in hpxml_heating_systems.items():
+            frac_load_str = self.xpath(el, 'h:FractionHeatLoadServed/text()')
+            if frac_load_str is not None:
+                frac_load = Decimal(frac_load_str)
+                if frac_load == Decimal(0):
+                    del hpxml_heating_systems[key]
+
         # Get all cooling systems
         hpxml_cooling_systems = _get_dict_of_hpxml_elements_by_id('descendant::h:HVACPlant/h:CoolingSystem|descendant::h:HVACPlant/h:HeatPump')
+
+        # Remove cooling systems that serve 0% of the cooling load
+        for key, el in hpxml_cooling_systems.items():
+            frac_load_str = self.xpath(el, 'h:FractionCoolLoadServed/text()')
+            if frac_load_str is not None:
+                frac_load = Decimal(frac_load_str)
+                if frac_load == Decimal(0):
+                    del hpxml_cooling_systems[key]
 
         # Get all the duct systems
         hpxml_distribution_systems = _get_dict_of_hpxml_elements_by_id('descendant::h:HVACDistribution')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -765,6 +765,26 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         res = tr.hpxml_to_hescore_dict()
         self.assertEqual('preconstruction', res['building_address']['assessment_type'])
 
+    def test_heatpump_no_heating(self):
+        tr = self._load_xmlfile('house3')
+        el = self.xpath('//h:HeatPump')
+        frac_load = etree.SubElement(el, tr.addns('h:FractionHeatLoadServed'))
+        frac_load.text = '0'
+        res = tr.hpxml_to_hescore_dict()
+        self.assertEqual(1, len(res['building']['systems']['hvac']))
+        self.assertEqual('heat_pump', res['building']['systems']['hvac'][0]['cooling']['type'])
+        self.assertEqual('none', res['building']['systems']['hvac'][0]['heating']['type'])
+
+    def test_heatpump_no_cooling(self):
+        tr = self._load_xmlfile('house3')
+        el = self.xpath('//h:HeatPump')
+        frac_load = etree.SubElement(el, tr.addns('h:FractionCoolLoadServed'))
+        frac_load.text = '0'
+        res = tr.hpxml_to_hescore_dict()
+        self.assertEqual(1, len(res['building']['systems']['hvac']))
+        self.assertEqual('heat_pump', res['building']['systems']['hvac'][0]['heating']['type'])
+        self.assertEqual('none', res['building']['systems']['hvac'][0]['cooling']['type'])
+
 
 class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
 


### PR DESCRIPTION
This permits the case where a heatpump is specified but only provides cooling or heating. To specify that a heat pump only provides heating `HeatPump/FractionCoolLoadServed` must be present and equal to `0`. Likewise `HeatPump/FractionHeatLoadServed` must be present and equal to `0` if the heat pump only provides cooling.

This will pass through cases where a heat pump provides heating and a separate air conditioner provides cooling to HEScore. However, it will fail on the HEScore side because it cannot handle that configuration.