### PR TITLE
Updating translator to work with hpxml v2.3

### DIFF
--- a/docs/source/translation/heating_system.rst
+++ b/docs/source/translation/heating_system.rst
@@ -59,6 +59,7 @@ is done according to the following mapping.
    =========================  ====================
    Furnace                    central_furnace
    WallFurnace                wall_furnace
+   FloorFurnace               wall_furnace
    Boiler                     boiler
    ElectricResistance         baseboard
    Stove                      wood_stove

--- a/docs/source/translation/zone_roof.rst
+++ b/docs/source/translation/zone_roof.rst
@@ -56,22 +56,19 @@ according to the following mapping.
 
 .. table:: HPXML to HEScore roof color mapping
 
-   ==========  =======
-   HPXML       HEScore
-   ==========  =======
-   light       light
-   medium      medium
-   dark        dark
-   reflective  white
-   ==========  =======
+   ===========  ===========
+   HPXML        HEScore
+   ===========  ===========
+   light        light
+   medium       medium
+   medium dark  medium_dark
+   dark         dark
+   reflective   white
+   ===========  ===========
 
-.. note::
-
-   HEScore allows for more detailed roof color descriptions than HPXML. 
-   There is no way in HPXML to specify the following HEScore roof colors:
-   
-   - medium_dark
-   - cool_color (along with the absorptivity, which is also missing an HPXML element.)
+If the ``Roof/SolarAbsorptance`` element is present, the HEScore roof color is
+set to "cool_color" and the recorded absorptance will be sent to HEScore under
+the "roof_absorptance" element.
 
 Exterior Finish
 ***************

--- a/examples/hescore_min.xml
+++ b/examples/hescore_min.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/house1-v2-2.xml
+++ b/examples/house1-v2-2.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>
@@ -12,15 +12,15 @@
             <SiteID id="address"/>
             <Address>
                 <AddressType>street</AddressType>
-                <Address1>2 API House</Address1>
-                <CityMunicipality>Tulsa</CityMunicipality>
-                <StateCode>OK</StateCode>
-                <ZipCode>74132</ZipCode>
+                <Address1>1 API House</Address1>
+                <CityMunicipality>Minden</CityMunicipality>
+                <StateCode>NE</StateCode>
+                <ZipCode>68959</ZipCode>
             </Address>
         </Site>
         <ProjectStatus>
             <EventType>audit</EventType>
-            <Date>2014-10-28</Date>
+            <Date>2014-10-23</Date>
         </ProjectStatus>
         <BuildingDetails>
             <BuildingSummary>
@@ -70,11 +70,21 @@
                         </FoundationType>
                         <FrameFloor>
                             <SystemIdentifier id="crawl1flr1"/>
-                            <Area>810</Area>
+                            <Area>405</Area>
                             <Insulation>
                                 <SystemIdentifier id="crawl1flr1ins1"/>
                                 <Layer>
                                     <NominalRValue>30</NominalRValue>
+                                </Layer>
+                            </Insulation>
+                        </FrameFloor>
+                        <FrameFloor>
+                            <SystemIdentifier id="crawl1flr2"/>
+                            <Area>405</Area>
+                            <Insulation>
+                                <SystemIdentifier id="crawl1flr2ins1"/>
+                                <Layer>
+                                    <NominalRValue>0</NominalRValue>
                                 </Layer>
                             </Insulation>
                         </FrameFloor>
@@ -101,48 +111,63 @@
                         <Area>108.0</Area><!-- 3x6 -->
                         <Quantity>6</Quantity>
                         <Orientation>east</Orientation>
-                        <UFactor>0.51</UFactor>
-                        <SHGC>0.35</SHGC>
+                        <FrameType>
+                            <Aluminum/>
+                        </FrameType>
+                        <GlassLayers>single-paned with storms</GlassLayers>
                     </Window>
                     <Window>
                         <SystemIdentifier id="rightwindows"/>
                         <Area>60.0</Area><!-- 3x5 -->
                         <Quantity>4</Quantity>
                         <Orientation>south</Orientation>
-                        <UFactor>0.67</UFactor>
-                        <SHGC>0.55</SHGC>
+                        <FrameType>
+                            <Wood/>
+                        </FrameType>
+                        <GlassLayers>single-paned with storms</GlassLayers>
                     </Window>
                     <Window>
                         <SystemIdentifier id="backwindows1"/>
                         <Area>54.0</Area><!-- 3x6 -->
                         <Quantity>3</Quantity>
                         <Orientation>west</Orientation>
-                        <UFactor>0.25</UFactor>
-                        <SHGC>0.42</SHGC>
+                        <FrameType>
+                            <Wood/>
+                        </FrameType>
+                        <GlassLayers>single-pane</GlassLayers>
+                        <GlassType>tinted</GlassType>
                     </Window>
                     <Window>
                         <SystemIdentifier id="backwindows2"/>
                         <Area>48.0</Area><!-- 3x4 -->
                         <Quantity>4</Quantity>
                         <Orientation>west</Orientation>
-                        <UFactor>0.25</UFactor>
-                        <SHGC>0.42</SHGC>
+                        <FrameType>
+                            <Wood/>
+                        </FrameType>
+                        <GlassLayers>single-pane</GlassLayers>
+                        <GlassType>tinted</GlassType>
                     </Window>
                     <Window>
                         <SystemIdentifier id="backwindows3"/>
                         <Area>33.3333333</Area><!-- 60"x80" -->
                         <Quantity>1</Quantity>
                         <Orientation>west</Orientation>
-                        <UFactor>0.25</UFactor>
-                        <SHGC>0.42</SHGC>
+                        <FrameType>
+                            <Aluminum/>
+                        </FrameType>
+                        <GlassLayers>single-pane</GlassLayers>
+                        <GlassType>tinted</GlassType>
                     </Window>
                     <Window>
                         <SystemIdentifier id="leftwindows"/>
                         <Area>45.0</Area><!-- 3x5 -->
                         <Quantity>3</Quantity>
                         <Orientation>north</Orientation>
-                        <UFactor>0.65</UFactor>
-                        <SHGC>0.80</SHGC>
+                        <FrameType>
+                            <Aluminum/>
+                        </FrameType>
+                        <GlassLayers>single-paned with storms</GlassLayers>
                     </Window>
                 </Windows>
             </Enclosure>
@@ -177,15 +202,27 @@
                         <SystemIdentifier id="ductsys1"/>
                         <DistributionSystemType>
                             <AirDistribution>
+                                <DuctLeakageMeasurement>
+                                    <!-- indicate that it is sealed because the majority of the ducts in unconditioned spaces are unsealed -->
+                                    <LeakinessObservedVisualInspection>some observable leaks</LeakinessObservedVisualInspection>
+                                </DuctLeakageMeasurement>
                                 <Ducts>
                                     <DuctInsulationRValue>4</DuctInsulationRValue>
                                     <DuctLocation>vented crawlspace</DuctLocation>
                                     <FractionDuctArea>0.5</FractionDuctArea>
+                                    <!-- unsealed -->
                                 </Ducts>
                                 <Ducts>
                                     <DuctInsulationRValue>0</DuctInsulationRValue>
                                     <DuctLocation>conditioned space</DuctLocation>
-                                    <FractionDuctArea>0.5</FractionDuctArea>
+                                    <FractionDuctArea>0.15</FractionDuctArea>
+                                    <!-- unsealed -->
+                                </Ducts>
+                                <Ducts>
+                                    <DuctInsulationThickness>1</DuctInsulationThickness>
+                                    <DuctLocation>unconditioned attic</DuctLocation>
+                                    <FractionDuctArea>0.35</FractionDuctArea>
+                                    <!-- sealed -->
                                 </Ducts>
                             </AirDistribution>
                         </DistributionSystemType>

--- a/examples/house1.xml
+++ b/examples/house1.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/house3.xml
+++ b/examples/house3.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/house4.xml
+++ b/examples/house4.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/house5.xml
+++ b/examples/house5.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/house6.xml
+++ b/examples/house6.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/house7.xml
+++ b/examples/house7.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/house8.xml
+++ b/examples/house8.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/examples/townhouse_walls.xml
+++ b/examples/townhouse_walls.xml
@@ -1,4 +1,4 @@
-<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.2">
+<HPXML xmlns="http://hpxmlonline.com/2014/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="2.3">
     <XMLTransactionHeaderInformation>
         <XMLType/>
         <XMLGeneratedBy/>

--- a/hescorehpxml/schemas/hpxml-2.3.0/BaseElements.xsd
+++ b/hescorehpxml/schemas/hpxml-2.3.0/BaseElements.xsd
@@ -1,0 +1,4763 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2014/6"
+	targetNamespace="http://hpxmlonline.com/2014/6" elementFormDefault="qualified" version="2.3">
+	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
+	<xs:element name="XMLTransactionHeaderInformation">
+		<xs:annotation>
+			<xs:documentation>These are a series of elements that indicate the type of XML and basic descriptive data about the XML.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="XMLType" type="XMLType"/>
+				<xs:element name="XMLGeneratedBy" type="XMLGeneratedBy"/>
+				<xs:element name="CreatedDateAndTime" type="CreatedDateAndTime"/>
+				<xs:element name="Transaction" type="TransactionType"/>
+				<xs:element minOccurs="0" ref="extension"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="AddressInformation">
+		<xs:annotation>
+			<xs:documentation>Address information contains the basic descriptive elements of a location.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="AddressType" type="AddressTypeCode" minOccurs="0"/>
+			<xs:element name="Address1" type="xs:string" minOccurs="0"/>
+			<xs:element name="Address2" type="xs:string" minOccurs="0"/>
+			<xs:element name="CityMunicipality" type="xs:string" minOccurs="0"/>
+			<xs:element name="StateCode" type="StateCode" minOccurs="0"/>
+			<xs:element name="ZipCode" type="ZipCode" minOccurs="0"/>
+			<xs:element name="USPSBarCode" type="USPSBarCode" minOccurs="0"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SystemIdentifiersInfoType">
+		<xs:annotation>
+			<xs:documentation>System identifiers contain type codes and an identifier for both a sending and a receiving system.  These fields are needed to be able to transmit data between two systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
+				minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:ID" use="required">
+			<xs:annotation>
+				<xs:documentation>id local to the current document</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="sameas" type="xs:IDREF">
+			<xs:annotation>
+				<xs:documentation>Use to reference the id of the same object on the base building where the object has not been replaced.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="LocalReference">
+		<xs:attribute name="idref" type="xs:IDREF"/>
+	</xs:complexType>
+	<xs:complexType name="RemoteReference">
+		<xs:annotation>
+			<xs:documentation>Use the id attribute if the element being referenced is available locally in the current xml transaction. Use the Sending/Receiving System Identifiers to identify elements in other xml transactions.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
+				minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:IDREF">
+			<xs:annotation>
+				<xs:documentation>Id reference in the current document. Optional. If the element isn't available in the current document, don't use this.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:element name="ContractorSystemIdentifiers">
+		<xs:annotation>
+			<xs:documentation>These are the system identifiers for a specific contractor at a business</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element maxOccurs="unbounded" ref="SystemIdentifiersInfo"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="extensionType">
+		<xs:sequence>
+			<xs:any maxOccurs="unbounded" minOccurs="0" namespace="##any" processContents="skip"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="extension" type="extensionType"> </xs:element>
+	<xs:element name="ProjectStatus">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="EventType" type="EventType">
+					<xs:annotation>
+						<xs:documentation>Quality assurance: The observation techniques and activities used externally by an organization to evaluate the effectiveness of their quality management system and to provide feedback that may result in quality improvements (BPI, 2006). </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element minOccurs="0" name="Date" type="xs:date"/>
+				<xs:element minOccurs="0" ref="extension"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="IndividualInfo">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element name="Name">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="PrefixName" type="PrefixName" minOccurs="0"/>
+						<xs:element name="FirstName" type="xs:string"/>
+						<xs:element name="MiddleName" type="xs:string" minOccurs="0"/>
+						<xs:element name="LastName" type="xs:string"/>
+						<xs:element name="SuffixName" type="SuffixName" minOccurs="0"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone"
+				type="TelephoneInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="UtilityFuelProvider">
+		<xs:annotation>
+			<xs:documentation>Utility company or fuel provider</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="SystemInfo"/>
+				<xs:element name="UtilityName" type="xs:string" minOccurs="0"/>
+				<xs:element minOccurs="0" name="MeterNumber" type="xs:string"/>
+				<xs:element name="UtilityAccountNumber" type="xs:string" minOccurs="0"/>
+				<xs:element minOccurs="0" name="Permission" type="xs:boolean"/>
+				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0"
+					maxOccurs="unbounded"/>
+				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo"
+					type="BusinessContactInfoType"/>
+				<xs:element ref="extension" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="IECCClimateZoneType">
+		<xs:sequence>
+			<xs:element name="Year" type="IECCYear"> </xs:element>
+			<xs:element name="ClimateZone" type="ClimateZoneIECC"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InsulationMaterial">
+		<xs:choice>
+			<xs:element name="Batt" type="InsulationBattType"/>
+			<xs:element name="LooseFill" type="InsulationLooseFillType"/>
+			<xs:element name="Rigid" type="InsulationRigidType"/>
+			<xs:element name="SprayFoam" type="InsulationSprayFoamType"/>
+			<xs:element name="Other" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Describe</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="None"/>
+			<xs:element name="Unknown"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="InsulationInfo">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
+			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
+			<xs:element minOccurs="0" name="InsulationLocation" type="InsulationLocation"/>
+			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="RValue">
+				<xs:annotation>
+					<xs:documentation>This should indicate the effective R-value of the complete assembly including any air films or other treatments.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="MisalignedInsulation" type="xs:boolean"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer">
+				<xs:complexType>
+					<xs:sequence maxOccurs="1">
+						<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
+						<xs:element name="InsulationMaterial" type="InsulationMaterial"
+							minOccurs="0"/>
+						<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
+						<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>[in]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="CoolingSystemInfo" type="CoolingSystemInfoType"/>
+	<xs:element name="HeatPumpInfo" type="HeatPumpInfoType"/>
+	<xs:element name="HeatingSystemInfo" type="HeatingSystemInfoType"/>
+	<xs:complexType name="ApplianceTypeSummaryInfo">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" ref="AttachedToSpace"/>
+			<xs:element name="NumberofUnits" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
+			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+			<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
+			<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="ApplianceThirdPartyCertifications"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClothesDryerInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+				<xs:sequence>
+					<xs:element minOccurs="0" name="Type" type="ClothesDryerType"/>
+					<xs:element minOccurs="0" name="Location" type="LaundryMachineLocation"/>
+					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
+					<xs:element minOccurs="0" name="Usage" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>loads/week</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="EfficiencyFactor" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>lbs dry clothes/kWh</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="timer"/>
+								<xs:enumeration value="moisture"/>
+								<xs:enumeration value="temperature"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ClothesWasherInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+
+				<xs:sequence>
+					<xs:element name="Type" type="ClothesWasherType" minOccurs="0"/>
+					<xs:element minOccurs="0" name="Location" type="LaundryMachineLocation"/>
+					<xs:element name="ModifiedEnergyFactor" type="xs:double" minOccurs="0"/>
+					<xs:element name="WaterFactor" type="xs:double" minOccurs="0"/>
+					<xs:element minOccurs="0" name="Usage" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>loads/week</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh">
+						<xs:annotation>
+							<xs:documentation>kWh/yr</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="LabelElectricRate" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>$/kWh</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="LabelGasRate" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>$/therm</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>$</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="Capacity" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>ft^3</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="DishwasherInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+				<xs:sequence>
+					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
+					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
+					<xs:element name="HeatDryDefaultOff" type="xs:boolean" minOccurs="0"/>
+					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="xs:boolean"
+						minOccurs="0"/>
+					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
+					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle"
+						type="RatedWaterGalPerCycle"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity"
+						type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="Usage" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>loads/week</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FreezerInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+				<xs:sequence>
+					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
+					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
+					<xs:element name="Configuration" type="FreezerStyle" minOccurs="0"/>
+					<xs:element name="Volume" type="Volume" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>[cu.ft.]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RefrigeratorInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+				<xs:sequence>
+					<xs:element name="Type" type="RefrigeratorStyle" minOccurs="0"/>
+					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
+					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
+					<xs:element name="PrimaryIndicator" type="xs:boolean" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>True if it is the primary refrigerator</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Volume" type="Volume" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>[cu.ft.]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="FreshVolume" type="Volume">
+						<xs:annotation>
+							<xs:documentation>[cu.ft.] Volume of refrigerator for keeping food at less than freezing.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="FrozenVolume" type="Volume">
+						<xs:annotation>
+							<xs:documentation>[cu.ft.] Freezer Volume</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DehumidifierInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+				<xs:sequence>
+					<xs:element minOccurs="0" name="Location" type="DehumidifierLocation"/>
+					<xs:element minOccurs="0" name="Efficiency" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>[L/kWh]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CookingRangeInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+				<xs:sequence>
+					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
+					<xs:element minOccurs="0" name="IsInduction" type="xs:boolean"/>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OvenInfoType">
+		<xs:complexContent>
+			<xs:extension base="ApplianceTypeSummaryInfo">
+				<xs:sequence>
+					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
+					<xs:element minOccurs="0" name="IsConvection" type="xs:boolean"/>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="SoftwareInfo">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion"
+					minOccurs="0"/>
+				<xs:element ref="extension" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="BusinessContactType">
+		<xs:choice>
+			<xs:element name="Owner">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Auditor">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification"
+							maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
+							type="StateCode"/>
+						<xs:element minOccurs="0" name="YearsExperience"
+							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Implementer">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification"
+							type="ImplementerQualification"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
+							type="StateCode"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Description" type="xs:string"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ContractorType">
+		<xs:sequence>
+			<xs:group maxOccurs="unbounded" ref="SystemInfo"/>
+			<xs:element name="BusinessInfo" type="BusinessInfoType"/>
+			<xs:element name="SubContractor" type="ContractorType" minOccurs="0"
+				maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="AttachedToSpace" type="LocalReference"/>
+	<xs:element name="AttachedToZone" type="LocalReference"/>
+	<xs:complexType name="Spaces">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" name="Space">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element name="SpaceName" type="xs:string" minOccurs="0"/>
+						<xs:element minOccurs="0" name="NumberOfBedrooms"
+							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
+							<xs:annotation>
+								<xs:documentation>[sq.ft.]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="Volume" type="Volume">
+							<xs:annotation>
+								<xs:documentation>[cu.ft.]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="CeilingHeight" type="LengthMeasurement">
+							<xs:annotation>
+								<xs:documentation>[ft]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Zones">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" name="Zone">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element name="ZoneName" type="xs:string" minOccurs="0"/>
+						<xs:element name="ZoneType" type="ZoneType" minOccurs="0"> </xs:element>
+						<xs:element name="Spaces" type="Spaces" minOccurs="0"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Enclosure">
+		<xs:sequence>
+			<xs:element name="AirInfiltration" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="AirInfiltrationMeasurement"
+							type="AirInfiltrationMeasurementType" maxOccurs="unbounded"> </xs:element>
+						<xs:element minOccurs="0" name="AirSealing" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element name="Hours" type="Hours" minOccurs="0"/>
+									<xs:element minOccurs="0" name="ComponentsAirSealed">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="Attic" type="AtticComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="BasementCrawlspace"
+												type="BasementCrawlspaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="LivingSpace"
+												type="LivingSpaceComponentsAirSealed"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AnnualEnergyUse" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="AtticAndRoof" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Roofs">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Roof" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" ref="AttachedToSpace"/>
+												<xs:element minOccurs="0" name="RoofColor"
+												type="WallAndRoofColor"/>
+												<xs:element minOccurs="0" name="SolarAbsorptance"
+													type="SolarAbsorptance"/>
+												<xs:element minOccurs="0" name="Emittance"
+													type="Emittance"/>
+												<xs:element minOccurs="0" name="RoofType"
+												type="RoofType"/>
+												<xs:element minOccurs="0" name="DeckType"
+												type="DeckType"/>
+												<xs:element minOccurs="0" name="Pitch" type="Pitch">
+												<xs:annotation>
+												<xs:documentation>Pitch of roof ?/12</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="RoofArea"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element name="RadiantBarrier" type="xs:boolean"
+												minOccurs="0"/>
+												<xs:element name="RadiantBarrierLocation"
+												type="RadiantBarrierLocation" minOccurs="0"/>
+												<xs:element ref="extension" minOccurs="0"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="Attics">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element maxOccurs="unbounded" name="Attic">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" ref="AttachedToSpace">
+												<xs:annotation>
+												<xs:documentation>The space over which this attic is</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="AttachedToRoof"
+												type="LocalReference"/>
+												<xs:element name="ExteriorAdjacentTo"
+												type="AdjacentTo" minOccurs="0"> </xs:element>
+												<xs:element minOccurs="0" name="InteriorAdjacentTo"
+												type="AdjacentTo"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="AtticKneeWall" type="LocalReference"> </xs:element>
+												<xs:element name="AtticType" type="AtticType"
+												minOccurs="0"/>
+												<xs:element minOccurs="0"
+												name="AtticFloorInsulation" type="InsulationInfo">
+												<xs:annotation>
+												<xs:documentation>For attic floor insulation that covers the rafters, two layers should be defined: 1.) a cavity later with thickness equal to the rafter height, and 2.) a continuous layer above that.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="AtticRoofInsulation"
+												type="InsulationInfo"/>
+												<xs:element name="Area" type="SurfaceArea"
+												minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Area of the floor of the attic.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Rafters"
+												type="StudProperties"/>
+												<xs:element ref="extension" minOccurs="0"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AnnualEnergyUse" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Foundations" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Foundation" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Use a different Foundation element for each type of foundation.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" ref="AttachedToSpace"/>
+									<xs:element name="FoundationType" type="FoundationType"/>
+									<xs:element minOccurs="0" name="ThermalBoundary"
+										type="FoundationThermalBoundary"/>
+									<xs:element name="FrameFloor" maxOccurs="unbounded"
+										minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="FloorJoists"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="FloorTrusses"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="FloorCovering"
+												type="FloorCovering"/>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" maxOccurs="1"
+												name="Insulation" type="InsulationInfo"> </xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="FoundationWall" maxOccurs="unbounded"
+										minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="Type"
+												type="FoundationWallType"/>
+												<xs:element minOccurs="0" name="Length"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Total length of foundation wall</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Height"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Total height in feet of foundation wall</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in] Thickness of foundation wall excluding interior framing.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="BelowGradeDepth"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="AdjacentToFoundation" type="LocalReference">
+												<xs:annotation>
+												<xs:documentation>If this foundation wall is adjacent to another foundation, use this reference to indicate which one.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="AdjacentTo"
+												type="AdjacentTo"/>
+												<xs:element minOccurs="0" name="InteriorStuds"
+												type="StudProperties"/>
+												<xs:element maxOccurs="1" minOccurs="0"
+												name="Insulation" type="InsulationInfo"/>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="Slab" maxOccurs="unbounded" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in] Thickness of foundation slab.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Perimeter"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="ExposedPerimeter"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="PerimeterInsulationDepth"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Depth from grade to bottom of vertical slab perimeter insulation</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="UnderSlabInsulationWidth"
+												type="LengthMeasurement"/>
+												<xs:element minOccurs="0"
+												name="OnGradeExposedPerimeter"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Perimeter of slab measuerd in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="DepthBelowGrade"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FloorCovering"
+												type="FloorCovering"/>
+												<xs:element maxOccurs="1" minOccurs="0"
+												name="PerimeterInsulation" type="InsulationInfo"/>
+												<xs:element minOccurs="0" name="UnderSlabInsulation"
+												type="InsulationInfo"/>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="RimJoists">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="RimJoist">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" ref="AttachedToSpace"/>
+									<xs:element minOccurs="0" name="ExteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="Insulation"
+										type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorJoists"
+										type="StudProperties"/>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Walls" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Wall" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" ref="AttachedToSpace"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
+										minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element name="WallType" type="WallType" minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="Thickness"
+										type="LengthMeasurement">
+										<xs:annotation>
+											<xs:documentation>[in] Thickness of the wall assembly</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
+									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[deg]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
+									<xs:element minOccurs="0" name="Siding" type="Siding"/>
+									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
+										type="InsulationInfo"/>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Windows" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Window" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>The Window element can be used to describe a single window or a group of windows with the same characteristics. For a group of windows, use the sum of the window areas in the Area subelement.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="WindowInfo"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio"
+										type="Fraction"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference"/>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Skylights">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="Skylight">
+							<xs:annotation>
+								<xs:documentation>The Skylight element can be used to describe a single skylight or a group of skylights with the same characteristics. For a group of skylights, use the sum of the skylight areas in the Area subelement.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="WindowInfo"/>
+									<xs:element minOccurs="0" name="SolarTube" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="Pitch" type="Pitch">
+										<xs:annotation>
+											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="AttachedToRoof"
+										type="LocalReference"/>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Doors" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Door" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference"/>
+									<xs:element minOccurs="0" name="Quantity"
+										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.] door area</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[deg]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="DoorType" type="DoorType"/>
+									<xs:element name="DoorMaterial" type="DoorMaterial"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="WeatherStripping"
+										type="xs:boolean"/>
+									<xs:element name="StormDoor" type="xs:boolean" minOccurs="0"/>
+									<xs:element name="RValue" type="RValue" minOccurs="0"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="ThirdPartyCertification"
+										type="DoorThirdPartyCertifications"/>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Systems">
+		<xs:sequence>
+			<xs:element name="HVAC" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="HVACPlant" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="PrimarySystems">
+										<xs:annotation>
+											<xs:documentation>Use these to reference which heating, cooling, or heat pump are the primary systems.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0"
+												name="PrimaryHeatingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0"
+												name="PrimaryCoolingSystem" type="LocalReference"
+												/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" maxOccurs="unbounded"
+										name="HeatingSystem" type="HeatingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded"
+										name="CoolingSystem" type="CoolingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump"
+										type="HeatPumpInfoType"/>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl"
+							type="HVACControlType"> </xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACDistribution">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" ref="AttachedToZone"/>
+									<xs:element minOccurs="0" name="DistributionSystemType">
+										<xs:complexType>
+											<xs:choice>
+												<xs:element name="AirDistribution"
+												type="AirDistributionInfo"/>
+												<xs:element name="HydronicDistribution"
+												type="HydronicDistributionInfo"/>
+												<xs:element name="Other" type="xs:string">
+												<xs:annotation>
+												<xs:documentation>describe</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+											</xs:choice>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0"
+										name="AnnualHeatingDistributionSystemEfficiency"
+										type="xs:double">
+										<xs:annotation>
+											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0"
+										name="AnnualCoolingDistributionSystemEfficiency"
+										type="xs:double">
+										<xs:annotation>
+											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HVACDistributionImprovement"
+										type="HVACDistributionImprovementInfo"/>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="Maintenance">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="Schedule"
+										type="HVACMaintenanceSchedule"/>
+									<xs:element minOccurs="0" name="ACReplacedinLastTenYears"
+										type="xs:boolean"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AnnualEnergyUse" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
+										maxOccurs="unbounded"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="MechanicalVentilation">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="VentilationFans">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element maxOccurs="unbounded" name="VentilationFan">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="Manufacturer"
+												type="xs:string"/>
+												<xs:element minOccurs="0" name="SerialNumber"
+												type="xs:string"/>
+												<xs:element minOccurs="0" name="FanType"
+												type="VentilationFanType"/>
+												<xs:element minOccurs="0" name="RatedFlowRate"
+												type="xs:double">
+												<xs:annotation>
+												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="CalculatedFlowRate"
+												type="xs:double">
+												<xs:annotation>
+												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="TestedFlowRate"
+												type="xs:double">
+												<xs:annotation>
+												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="HoursInOperation"
+												type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="DeliveredVentilation" type="xs:double">
+												<xs:annotation>
+												<xs:documentation>[CFM]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="FanControlProperlyLabeled"
+												type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="ProperlyVented"
+												type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="FanLocation"
+												type="VentilationFanLocation"/>
+												<xs:element minOccurs="0"
+												name="UsedForLocalVentilation" type="xs:boolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForWholeBuildingVentilation"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForSeasonalCoolingLoadReduction"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForGarageVentilation" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="RatedNoise"
+												type="xs:double">
+												<xs:annotation>
+												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="TestedNoise"
+												type="xs:double">
+												<xs:annotation>
+												<xs:documentation>[sones] as tested in field</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="TotalRecoveryEfficiency" type="Fraction">
+												<xs:annotation>
+												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="SensibleRecoveryEfficiency" type="Fraction">
+												<xs:annotation>
+												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain, air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FanPower"
+												type="xs:double">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="ThirdPartyCertification"
+												type="VentilationFanThirdPartyCertification"/>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="CombustionVentilation">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="CombustionVentilationSystem">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="VentSystemType"
+										type="VentSystem"/>
+									<xs:element minOccurs="0" ref="AttachedToZone"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="WaterHeating" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="WaterHeatingSystem">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" ref="AttachedToZone"/>
+									<xs:element minOccurs="0" name="AttachedToCAZ"
+										type="LocalReference"/>
+									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
+									<xs:element name="WaterHeaterType" type="WaterHeaterType"
+										minOccurs="0"/>
+									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
+									<xs:element name="Manufacturer" type="Manufacturer"
+										minOccurs="0"/>
+									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+									<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment"
+										type="Fraction"/>
+									<xs:element minOccurs="0" name="ThirdPartyCertification"
+										type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
+									<xs:element name="TankVolume" type="Volume" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[gal]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="FractionDHWLoadServed"
+										type="Fraction"/>
+									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[Btuh]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="EnergyFactor" type="EnergyFactor"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>The amount of energy delivered as heated water in a day divided by the total daily energy consumption of a residential water heater, as determined following standardized DOE testing procedure.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="UniformEnergyFactor" type="EnergyFactor"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>DOE’s new metric for communicating the energy efficiency of a residential water heater, which replaces the Energy Factor (EF) metric. More efficient water heaters have a higher Uniform Energy Factor (UEF). UEF is determined by the Department of Energy’s test method outlined in 10 CFR Part 430, Subpart B, Appendix E.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="FirstHourRating" type="Volume">
+										<xs:annotation>
+											<xs:documentation>[gal per hour] An estimate of the maximum volume of hot water in gallons that a storage water heater can supply within an hour that begins with the water heater fully heated.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="GallonsPerMinute" type="Volume">
+										<xs:annotation>
+											<xs:documentation>[gal per minute] The amount of gallons per minute of hot water that can be supplied by an instantaneous water heater while maintaining a nominal temperature rise of 77°F during steady state operation.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>The ratio of energy delivered to heat cold water compared to the energy consumed by the water heater, as determined following standardized DOE testing procedure.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ThermalEfficiency" type="ThermalEfficiency"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="WaterHeaterInsulation">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="Jacket">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element name="JacketRValue" type="RValue"
+												minOccurs="0"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												<xs:element minOccurs="0" name="Pipe"
+												type="PipeInsulationType">
+												<xs:annotation>
+												<xs:documentation>DEPRECATED. This will be removed in v3.0. Use HotWaterDistribution element instead.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="MeetsACCA5QIHVACSpecification"
+										type="xs:boolean" minOccurs="0"/>
+									<xs:element name="HotWaterTemperature" type="Temperature"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[deg F]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HasGeothermalDesuperheater"
+										type="xs:boolean">
+										<xs:annotation>
+											<xs:documentation>Indicates whether this water heater has a geothermal desuperheater. The attached heat pump can be referenced in the RelatedHeatingSystem element.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"
+										type="xs:boolean"/>
+									<xs:element minOccurs="0" name="CombustionVentilationOrphaned"
+										type="xs:boolean"/>
+									<xs:element name="CombustionVentingSystem" minOccurs="0"
+										type="LocalReference"> </xs:element>
+									<xs:element name="RelatedHeatingSystem" type="LocalReference"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="Installation">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="Standard"
+												type="HVACInstallationStandard"/>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="WaterHeaterImprovement"
+										type="WaterHeaterImprovementInfo"/>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HotWaterDistribution">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem"
+										type="LocalReference">
+										<xs:annotation>
+											<xs:documentation>The water heating system that his distribution system serves.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="SystemType">
+										<xs:complexType>
+											<xs:choice>
+												<xs:element name="Standard">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="PipingLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level, plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												<xs:element name="Recirculation">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="ControlType"
+												type="RecirculationControlType"/>
+												<xs:element minOccurs="0"
+												name="RecirculationPipingLoopLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="BranchPipingLoopLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20 feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="PumpPower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+											</xs:choice>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="PipeInsulation"
+										type="PipeInsulationType"/>
+									<xs:element minOccurs="0" name="DrainWaterHeatRecovery">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="FacilitiesConnected"
+												type="DrainWaterHeatRecoveryFacilitiesConnected"/>
+												<xs:element minOccurs="0" name="EqualFlow"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0" name="Efficiency"
+												type="Fraction">
+												<xs:annotation>
+												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterFixture">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:choice minOccurs="0">
+										<xs:element name="AttachedToWaterHeatingSystem"
+											type="LocalReference"/>
+										<xs:element name="AttachedToHotWaterDistribution"
+											type="LocalReference"/>
+									</xs:choice>
+									<xs:element minOccurs="1" name="WaterFixtureType"
+										type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="FlowRate" type="xs:double">
+										<xs:annotation>
+											<xs:documentation>[gallons per minute] flow rate of water</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="FaucetAerator" type="xs:boolean">
+										<xs:annotation>
+											<xs:documentation>Does this faucet have an aerator?</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0"
+										name="TemperatureInitiatedShowerFlowRestrictionValve"
+										type="xs:boolean">
+										<xs:annotation>
+											<xs:documentation>Does the shower have a device that restricts the flow of water automatically once it has reached temperature?</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="ThirdPartyCertification"
+										type="WaterFixtureThirdPartyCertification">
+										<xs:annotation>
+											<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AnnualEnergyUse" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="SolarThermal">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="SolarThermalSystem">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
+									<xs:element minOccurs="0" name="ModelNumber" type="xs:string"/>
+									<xs:element minOccurs="0" ref="AttachedToZone"/>
+									<xs:element name="SystemType" minOccurs="0"
+										type="SolarThermalSystemType"/>
+									<xs:element name="CollectorArea" type="SurfaceArea"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="CollectorLoopType"
+										type="SolarThermalCollectorLoopType">
+										<xs:annotation>
+											<xs:documentation>"batch heater" enumeration is deprecated. It will be removed in a future version. See #272.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="CollectorType"
+										type="SolarThermalCollectorType"/>
+									<xs:element minOccurs="0" name="CollectorOrientation"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="CollectorAzimuth"
+										type="AzimuthType"/>
+									<xs:element minOccurs="0" name="CollectorTilt" type="Tilt">
+										<xs:annotation>
+											<xs:documentation>[deg]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="StorageVolume" type="Volume">
+										<xs:annotation>
+											<xs:documentation>[gal]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="ConnectedTo"
+										type="LocalReference"/>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Photovoltaics">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="PVSystem">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Location"
+										type="PVSystemLocation"/>
+									<xs:element minOccurs="0" name="Ownership"
+										type="PVSystemOwnership"/>
+									<xs:element minOccurs="0" name="ArrayOrientation"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
+										<xs:annotation>
+											<xs:documentation>[deg]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="ArrayTilt" type="Tilt">
+										<xs:annotation>
+											<xs:documentation>[deg]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="MaxPowerOutput" type="Power">
+										<xs:annotation>
+											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="CollectorArea"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="InverterEfficiency"
+										type="Efficiency"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured"
+										type="Year"/>
+									<xs:element minOccurs="0" name="YearModulesManufactured"
+										type="Year"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element minOccurs="0" name="AnnualOutput"
+										type="RatedAnnualkWh">
+										<xs:annotation>
+											<xs:documentation>[kWh] Projected Annual Output for a typical meterological year as determined by PVWatts or similar. </xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
+										type="Cost">
+										<xs:annotation>
+											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at http://www.nrel.gov/analysis/tech_lcoe.html.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Wind">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="WindTurbine">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Model" type="xs:string"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element minOccurs="0" name="ThirdPartyCertification"
+										maxOccurs="unbounded" type="WindThirdPartyCertification"/>
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy"
+										type="RatedAnnualkWh">
+										<xs:annotation>
+											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2 mph)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="AWEARatedSoundLevel"
+										type="xs:double">
+										<xs:annotation>
+											<xs:documentation>[dBA] the sound pressure level not exceeded by the wind turbine 95% of the time at a distance of 60 meters from the rotor with an average wind speed of 5 m/s (11.2 mph).
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="AWEARatedPower" type="Power">
+										<xs:annotation>
+											<xs:documentation>[kW] the wind turbine’s power output at 11 m/s (24.6 mph). Manufacturers may still describe or name their wind turbine models using a nominal power (e.g. 5 kW S-343).</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="PeakPower" type="Power">
+										<xs:annotation>
+											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="RotorDiameter"
+										type="LengthMeasurement">
+										<xs:annotation>
+											<xs:documentation>[ft]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HubHeight"
+										type="LengthMeasurement">
+										<xs:annotation>
+											<xs:documentation>[ft]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
+										type="Cost">
+										<xs:annotation>
+											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at http://www.nrel.gov/analysis/tech_lcoe.html.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Appliances">
+		<xs:sequence>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher"
+				type="ClothesWasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer"
+				type="ClothesDryerInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher"
+				type="DishwasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator"
+				type="RefrigeratorInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Freezer" type="FreezerInfoType"/>
+			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0"
+				type="DehumidifierInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange"
+				type="CookingRangeInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Lighting">
+		<xs:sequence>
+			<xs:element name="LightingGroup" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Light units of the same type. For example you could have all the 60W incandescants.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="Fixture" type="LocalReference">
+							<xs:annotation>
+								<xs:documentation>The LightingFixture that this is attached to</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="AttachedToSpace"/>
+						<xs:element minOccurs="0" name="Location" type="LightingLocation"/>
+						<xs:element name="NumberofUnits" type="xs:integer" minOccurs="0"/>
+						<xs:element minOccurs="0" name="LightingType" type="LightingType"/>
+						<xs:element minOccurs="0" name="AverageLumens" type="xs:double">
+							<xs:annotation>
+								<xs:documentation>Lumens is a measure of light output (brightness) as opposed to watts, which measures energy consumption. The EPA and DOE encourages people to determine the amount of light they need (or brightness) first before purchasing a light bulb. Once brightness is determined, you can look for the bulb with the lowest watts.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="AverageWattage" type="xs:double" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>[W] per unit</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0"
+							name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
+						<xs:element name="AverageHoursPerDay" type="HoursPerDay" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>[h]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LightingDailyHours"
+							type="LightingDailyHours">
+							<xs:annotation>
+								<xs:documentation>[h]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+							<xs:annotation>
+								<xs:documentation>[sq.ft.]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="LightingFixture">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0"
+							name="ThirdPartyCertification"
+							type="LightingFixtureThirdPartyCertification"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="LightingControl" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="AttachedToLightingGroup"
+							type="LocalReference"/>
+						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"
+							> </xs:element>
+						<xs:element name="NumberofLightingControls"
+							type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Location" type="LightingLocation" minOccurs="0"> </xs:element>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="LightingFractions">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="FractionIncandescent" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>Fraction of lights that are incandescent.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="FractionCFL" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>Fraction of the lights that are compact fluorescent.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="FractionLFL" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>Fraction of the lights that are linear fluorescent.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="FractionLED" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>Fraction of lights that are LED.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="CeilingFan">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element maxOccurs="3" minOccurs="0" name="Airflow">
+							<xs:annotation>
+								<xs:documentation/>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="FanSpeed">
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:enumeration value="low"/>
+												<xs:enumeration value="medium"/>
+												<xs:enumeration value="high"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element minOccurs="0" name="Airflow" type="xs:double">
+										<xs:annotation>
+											<xs:documentation>[CFM]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="Efficiency" type="xs:double">
+										<xs:annotation>
+											<xs:documentation>[CFM/watt] The efficiency rating of a ceiling fan as determined by the test procedure defined by the Environmental Protection Agency's ENERGY STAR Testing Facility Guidance Manual: Building a Testing Facility and Performing the Solid State Test Method for ENERGY STAR Qualified Ceiling Fans, Version 1.1, December 9, 2002. This is generally printed on the box in which the ceiling fan is shipped.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="ThirdPartyCertification"
+							type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LightingType">
+		<xs:choice>
+			<xs:element name="Incandescent">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Halogen" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="FluorescentTube">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="TubeType" type="FluorescentTubeType"/>
+						<xs:element minOccurs="0" name="BallastType" type="FluorescentBallastType"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="CompactFluorescent">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="LightEmittingDiode">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="HighIntensityDischarge">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Type">
+							<xs:complexType>
+								<xs:choice>
+									<xs:element name="MercuryVapor"/>
+									<xs:element name="Sodium">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="Pressure">
+												<xs:simpleType>
+												<xs:restriction base="xs:string">
+												<xs:enumeration value="high"/>
+												<xs:enumeration value="low"/>
+												</xs:restriction>
+												</xs:simpleType>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="MetalHalide"/>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Description" type="xs:string"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Pools">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" name="Pool">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="Type" type="PoolType">
+							<xs:annotation>
+								<xs:documentation>Indicates if the pool is above or below ground.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="Volume" type="Volume">
+							<xs:annotation>
+								<xs:documentation>[gal] Volume of pool.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="MonthsPerYearofOperation"
+							type="MonthsPerYear">
+							<xs:annotation>
+								<xs:documentation>Months per year pool is in operation.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="ReturnPipeDiameter" type="LengthMeasurement">
+							<xs:annotation>
+								<xs:documentation>[in]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="SuctionPipeDiameter"
+							type="LengthMeasurement">
+							<xs:annotation>
+								<xs:documentation>[in]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="FilterType" type="PoolFilterType">
+							<xs:annotation>
+								<xs:documentation>Type of filter used, if any.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="PoolPumps">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element maxOccurs="unbounded" name="PoolPump">
+										<xs:annotation>
+											<xs:documentation>Pool pump: a mechanical assembly consisting of a “wet-end,” which houses the impeller and a motor. The pump increases the “head” and “flow” of the water (ENERGY STAR, 2013).</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="Type"
+												type="PoolPumpType"/>
+												<xs:element minOccurs="0" name="Manufacturer"
+												type="xs:string">
+												<xs:annotation>
+												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="SerialNumber"
+												type="xs:string">
+												<xs:annotation>
+												<xs:documentation>Serial number of pool pump.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="ModelNumber"
+												type="xs:string">
+												<xs:annotation>
+												<xs:documentation>Model number of pool pump.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="ThirdPartyCertification"
+												type="PoolPump3rdPartyCertification"
+												maxOccurs="unbounded">
+												<xs:annotation>
+												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE, or other)</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="EnergyFactor"
+												type="Efficiency">
+												<xs:annotation>
+												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is calculated as: EF (gal/Wh) = flow rate (gpm) * 60 ÷ power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="SpeedSetting"
+												type="PoolPumpSpeedSetting">
+												<xs:annotation>
+												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="RatedHorsepower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15 2011).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="TotalHorsepower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class (e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="ServiceFactor"
+												type="xs:double">
+												<xs:annotation>
+												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters, such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="HoursPerDay"
+												type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>DEPRECATED - Please use PumpSpeed/HoursPerDay</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="PumpSpeed">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="Power"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="MotorNominalSpeed"
+												type="Speed">
+												<xs:annotation>
+												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FlowRate"
+												type="FlowRate">
+												<xs:annotation>
+												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="HoursPerDay"
+												type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="Cleaner">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Type" type="PoolCleanerType">
+										<xs:annotation>
+											<xs:documentation>Type of pool cleaner used, if any.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
+										<xs:annotation>
+											<xs:documentation>Hours per day pool cleaner is used. </xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="Heater">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Type" type="PoolHeaterType">
+										<xs:annotation>
+											<xs:documentation>Type of heater used to heat pool, if any.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
+										<xs:annotation>
+											<xs:documentation>Hours per day pool heater is used.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MiscLoads">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="PlugLoadControl">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" ref="AttachedToSpace"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
+							minOccurs="0"/>
+						<xs:element name="PlugLoadControlType" minOccurs="0"
+							type="PlugLoadControlType"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="PlugLoad" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" ref="AttachedToSpace"/>
+						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
+						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
+							minOccurs="0"/>
+						<xs:element minOccurs="0" name="Load">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Units" type="PlugLoadUnits"/>
+									<xs:element name="Value" type="xs:double"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HealthAndSafety">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="General">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="TestsCompleted" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="TestsPassed" type="xs:boolean"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Ventilation" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign"
+							type="WholeBldgVentDesignInfo"/>
+						<xs:element minOccurs="0" name="SpotVentilationDesign"
+							type="SpotVentDesignInfo"/>
+						<xs:element minOccurs="0" name="OtherVentilationIssues"
+							type="OtherVentIssues"/>
+						<xs:element minOccurs="0" name="VentilationImprovement"
+							type="VentilationImprovementInfo"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="MoistureControl" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="MoistureControlInfo"
+							type="MoistureControlInfoType"> </xs:element>
+						<xs:element minOccurs="0" name="MoistureControlImprovement"
+							type="MoistureControlImprovementInfo"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="CombustionAppliances">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="CombustionApplianceZone"
+							maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element name="CAZDepressurizationLimit"
+										type="CAZDepressurizationLimit" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="BaselineTest" type="CAZTestConfiguration"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Baseline pressure is read under the following conditions: no items running, all fans off, all exterior doors closed, and all interior doors are opened.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="PoorCaseTest"
+										type="CAZTestConfiguration">
+										<xs:annotation>
+											<xs:documentation>The poor case CAZ depressurization test is configured by determining the largest combustion appliance zone depressurization attainable at the time of testing due to the combined effects of door position, exhaust appliance operation, and air handler fan operation. A base pressure must be measured with all fans off and doors open. The poor case CAZ depressurization measurement is the pressure difference between the largest depressurization attained at the time of testing and the base pressure.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="NetPressureChange" type="NetPressureChange"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="DepressurizationFindingPoorCase"
+										type="DepressurizationFindingPoorCase" minOccurs="0"/>
+									<xs:element name="AmountAmbientCOinCAZduringTesting"
+										type="xs:double" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>parts per million (ppm)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting"
+										type="xs:boolean" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CombustionApplianceTest"
+										maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence minOccurs="0">
+												<xs:element name="CAZAppliance"
+												type="RemoteReference">
+												<xs:annotation>
+												<xs:documentation>The ID of the system tested</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="CombustionVentingSystem"
+												type="RemoteReference"/>
+												<xs:element name="FlueVisualCondition"
+												type="FlueCondition" minOccurs="0"/>
+												<xs:element minOccurs="0" name="FlueConditionNotes"
+												type="xs:string"/>
+												<xs:element name="OutsideTemperatureFlueDraftTest"
+												type="Temperature" minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg F]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FlueDraftTest">
+												<xs:annotation>
+												<xs:documentation>[Pa]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
+												</xs:element>
+												<xs:element minOccurs="0" name="SpillageTest">
+												<xs:annotation>
+												<xs:documentation>[seconds]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
+												</xs:element>
+												<xs:element minOccurs="0" name="CarbonMonoxideTest">
+												<xs:annotation>
+												<xs:documentation>[ppm]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element
+												name="MaxAmbientCOinLivingSpaceDuringAudit"
+												minOccurs="0" type="xs:double">
+												<xs:annotation>
+												<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="AmbientCOActionDuringCAZTesting"
+												type="xs:string">
+												<xs:annotation>
+												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
+												</xs:element>
+												<xs:element name="StackTemperature"
+												type="Temperature" minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element name="FuelLeaks" minOccurs="0"
+												maxOccurs="unbounded">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element name="FuelType" type="FuelType"/>
+												<xs:element name="LeaksIdentified"
+												type="xs:boolean"/>
+												<xs:element name="LeaksAddressed"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0" name="Notes"
+												type="xs:string"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												<xs:element ref="extension" minOccurs="0"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="Notes" type="xs:string"/>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="StoveTest">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
+						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
+						<xs:element name="HeatingStoveProperlyVented" type="xs:boolean"
+							minOccurs="0"/>
+						<xs:element name="COReading" type="COReading" minOccurs="0"/>
+						<xs:element minOccurs="0" name="TimeofCOReading" type="xs:dateTime"/>
+						<xs:element name="GasLeaksIdentified" type="xs:boolean" minOccurs="0"/>
+						<xs:element name="ActionsTaken" type="xs:string" minOccurs="0"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="LeadPaint">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Disturbed6SqFtIntPaint" type="xs:boolean" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>For a home built before 1978, did the contracted scope of work disturb greater than 6 sq.ft. of interior painted surfaces?
+</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="Disturbed20SqFtExtPaint" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>For a home built before 1978, did the contracted scope of work disturb greater than 20 sf of exterior painted surfaces?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="WindowReplacement" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LeadSafeCertificationNumber"
+							type="xs:string">
+							<xs:annotation>
+								<xs:documentation>Certification Number of the EPA Lead-Safe Certified firm that performed the work.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Radon">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="RadonTested" type="xs:boolean" minOccurs="0"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="RadonTest">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="StartDateTime"
+										type="xs:dateTime"/>
+									<xs:element minOccurs="0" name="EndDateTime" type="xs:dateTime"/>
+									<xs:element minOccurs="0" name="TestLocation"
+										type="RadonTestLocation"/>
+									<xs:element name="RadonTestResults" type="xs:double"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>in pCi/L</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="RadonTestMethod"
+										type="RadonTestTypes"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="EducationMaterialProvided" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Was the homeowner provided with educational material?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="ActionsTaken" type="xs:string"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>If moisture management of a crawlspace (e.g., installation of polyethylene sheeting) or radon mitigation measures were a part of the scope of work,were measures installed to be compliant with one of the following:
+- Specifications of EPA’s Indoor airPLUS program
+- Techniques detailed in EPA's Radon-Resistent New Construction
+- ASTM E2121, Standard Practice for Installing Radon Mitigation Systems in Existing Low-Rise Residential Buildings (section 7.3)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="ResultBelowActionLevel" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Was the result less than 4 pCi/L</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="SourcePollutants">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea"
+							type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Are there unvented combustion heating or hearth appliances present in the living area?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2"
+							type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>If yes, does the appliance conform with ANSI Z21.11.2?
+</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="PrimaryHeatingSource" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>If yes, is the appliance used as a primary source of heating?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="AttachedGarage" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Does home have attached garage?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="GarageContinuousAirBarrier"
+							type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>If yes, is there a continuous air barrier between garage and living space?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="GarageExhaustFan" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>If yes, is there an exhaust fan in garage?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Pests">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="IndicationsofPests" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Indications of pest entry or damage?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="EvidenceofPesticide" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Evidence of pesticide, insecticide use?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="IndustryStandardCompliance"
+							type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Do measures comply with industry standards to prevent pest entry?
+
+NOTE: This is for ALL measures that may create entry points for vermin. For example, air sealing measures identified to reduce infiltration should have proper sealants  - even if those measures were not recommended/installed for pest control purposes.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Asbestos">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="AsbestosSuspected" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Was asbestos suspected?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="TestedForAsbestos" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Was substance tested for asbestos?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="AsbestosFound" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Was asbestos found?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="TypeofBlowerDoorTest"
+							type="TypeofBlowerDoorTest"/>
+						<xs:element minOccurs="0" name="ActionsTaken" type="xs:string"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications"
+							type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="SprayFoam">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="SprayFoamInstalled" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Was spray foam polyurethane foam and / or other potential sources of indoor pollutants installed or applied as part of the scope of work?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CAZApplianceReading">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="PoorScenario" type="xs:double"/>
+			<xs:element minOccurs="0" name="CurrentCondition" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>This element is formerly known as "spillage, draft, and CO readings under natural conditions" as explained in BPI's Gold Sheet "Combustion Safety Test Procedure for Vented Appliances."</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="TestResult" type="TestResultType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CAZTestConfiguration">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="ItemsRunning">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="BathExhaustFan" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="KitchenExhaustFan" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="ClothesDryer" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="CentralVacuum" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="AirHandler" type="xs:boolean"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="DoorsOpenClosed">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="BasementDoors" type="OpenClosed"/>
+						<xs:element minOccurs="0" name="OtherDoors" type="OpenClosed"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Pressure" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>[Pa]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="YesNoRecommendInstall">
+		<xs:choice>
+			<xs:element name="Yes">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Installed" type="BooleanWithNA">
+							<xs:annotation>
+								<xs:documentation>If yes, was this installed as part of scope of work?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="No">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Recommended" type="BooleanWithNA">
+							<xs:annotation>
+								<xs:documentation>If no, was this recommended in scope of work?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="NA">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="WholeBldgVentDesignInfo">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" name="Method" type="WholeBldgVentilationRequirementMethod"/>
+			<xs:element minOccurs="0" name="InfiltrationCreditApplied" type="BooleanWithNA">
+				<xs:annotation>
+					<xs:documentation>ASHRAE 62.2-2010 has an infiltration credit. ASHRAE 62-89 and 62.2-2013 do not have infiltration credits.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="LocalWeatherFactor" type="xs:double"/>
+			<xs:element minOccurs="0" name="NFactor" type="xs:double"/>
+			<xs:element minOccurs="0" name="InfiltrationCreditCFMnat" type="xs:integer">
+				<xs:annotation>
+					<xs:documentation>This is just the # of the calculated infiltration credit.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="RequiredVentilationRate" type="xs:double">
+					<xs:annotation>
+						<xs:documentation>This is the net amount of continuous ventilation needed AFTER infiltration credit is applied (if any)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="RequiredVentilationRateUnits" type="VentilationRateUnits"/>
+			</xs:sequence>
+			<xs:element minOccurs="0" name="VentilationImprovementRecommendation"
+				type="Recommendation"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SpotVentDesignInfo">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" name="Location" type="SpotVentilationLocation"/>
+			<xs:element minOccurs="0" name="IntermittentExhaustRate" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>This is amount without taking into consideration any infiltration credit</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="ContinuousExhaustRate" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>This is amount without taking into consideration any infiltration credit</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="WindowOpeningCredit" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Should be 20 cfm, if the local AHJ permits windows to be used for local exhaust</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="RequiredIntermittentExhaustRate" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>This is the net amount of continuous ventilation needed AFTER window credit is applied (if any)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="RequiredContinuousExhaustRate" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>This is the net amount of continuous ventilation needed AFTER window credit is applied (if any)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="InitialAirflorDeficit" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>The airflow deficit for each bathroom or kitchen is the required airflow less the airflow rating of the exhaust equipment. If there is no exhaust device or if the existing device cannot be measured nor read it, the exhaust device airflow is assumed to be zero.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="AirflowRateUnits" type="SpotVentilationUnits"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OtherVentIssues">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" name="HouseGarageAirBarrier" type="YesNoRecommendInstall">
+				<xs:annotation>
+					<xs:documentation>Does a proper air barrier separate the house from the garage?</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="DuctsInGarageAirSealed" type="YesNoRecommendInstall">
+				<xs:annotation>
+					<xs:documentation>Are ducts and air handlers located in the garage properly air sealed?</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="ClothesDryerVented" type="YesNoRecommendInstall">
+				<xs:annotation>
+					<xs:documentation>Is the clothes dryer properly vented?</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="OtherVentilationIssue">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Description" type="xs:string"/>
+						<xs:element name="Answer" type="YesNoRecommendInstall"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StatusMessage">
+		<xs:sequence>
+			<xs:element name="MessageType" type="xs:string"/>
+			<xs:element name="MessageID" type="xs:string"/>
+			<xs:element name="Message" type="xs:string"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FuelSavingsType">
+		<xs:sequence>
+			<xs:element name="Fuel" type="FuelType"/>
+			<xs:element name="Units" type="energyUnitType" minOccurs="0"/>
+			<xs:element name="TotalSavings" type="xs:double" minOccurs="0"/>
+			<xs:element name="TotalDollarSavings" type="xs:double" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PctReduction" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings"
+				type="EndUseInfoType"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EndUseInfoType">
+		<xs:sequence>
+			<xs:element name="EndUse" type="endUseType"/>
+			<xs:element name="EndUseValue" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Energy use will be negative for energy producing end uses such as PV and SolarThermal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:group name="SystemInfo">
+		<xs:sequence>
+			<xs:element name="SystemIdentifier" type="SystemIdentifiersInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="HVACSystemInfo">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" ref="AttachedToZone"/>
+			<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
+			<xs:element name="UnitLocation" type="UnitLocation" minOccurs="0"/>
+			<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
+			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
+			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+			<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+			<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
+			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="HVACThirdPartyCertification"/>
+			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
+			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0"
+				maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="Installation">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
+						<xs:element minOccurs="0" name="SizingCalculation" type="HVACSizingCalcs"/>
+						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing"
+							type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Air sealing and insulation implemented prior to replacement and used in calculations for sizing new / replacement system?</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="AnnualEnergyUse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="HVACMaintenance" type="HVACMaintenance"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HeatingSystemInfoType">
+		<xs:complexContent>
+			<xs:extension base="HVACSystemInfo">
+				<xs:sequence minOccurs="1" maxOccurs="1">
+					<xs:element name="HeatingSystemType" type="HeatingSystemType" minOccurs="0"/>
+					<xs:element name="HeatingSystemFuel" type="FuelType" minOccurs="0"/>
+					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>[Btuh] Input Heating Capacity</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="AnnualHeatingEfficiency"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+						<xs:annotation>
+							<xs:documentation>[sq.ft.]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="HeatingSystemType">
+		<xs:choice>
+			<xs:element name="Furnace">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="SealedCombustion" type="xs:boolean"/>
+						<xs:element name="CondensingSystem" type="xs:boolean" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AtmosphericBurner" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="PowerBurner" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="WallFurnace" type="WallAndFloorFurnace"> </xs:element>
+			<xs:element name="FloorFurnace" type="WallAndFloorFurnace"/>
+			<xs:element name="Boiler">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="BoilerType" type="BoilerType"/>
+						<xs:element minOccurs="0" name="SealedCombustion" type="xs:boolean"/>
+						<xs:element name="CondensingSystem" type="xs:boolean" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AtmosphericBurner" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="PowerBurner" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="RotaryCup" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ElectricResistance">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ElectricDistribution" type="ElectricDistributionType"
+							minOccurs="0"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Fireplace">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="SmokeEmissionRate" type="xs:double">
+							<xs:annotation>
+								<xs:documentation>[grams per hour] from EPA label
+http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Stove">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="SmokeEmissionRate" type="xs:double">
+							<xs:annotation>
+								<xs:documentation>[grams per hour] from EPA label
+http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="PortableHeater">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SolarThermal">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="SolarThermalSystem" type="LocalReference"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="DistrictSteam">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="DistrictSteamType" type="DistrictSteamType"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Description" type="xs:string"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="HeatPumpInfoType">
+		<xs:complexContent>
+			<xs:extension base="HVACSystemInfo">
+				<xs:sequence minOccurs="0">
+					<xs:element name="HeatPumpType" type="HeatPumpType" minOccurs="0"/>
+					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>[Btuh] Typically the nameplate capacity at 47F.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="HeatingCapacity17F" type="Capacity">
+						<xs:annotation>
+							<xs:documentation>[Btuh] Capacity at 17F from AHRI database.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="CoolingCapacity" type="Capacity">
+						<xs:annotation>
+							<xs:documentation>[Btuh]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
+					<xs:element name="GeothermalLoop" type="GeothermalLoop" minOccurs="0"/>
+					<xs:element minOccurs="0" name="BackupType">
+						<xs:annotation>
+							<xs:documentation>Whether the heat pump backup is integrated into the unit (describe in BackupSystemFuel, BackupAFUE, BackupHeatingCapacity), or a separate heating system (add reference in BackupSystem).</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="integrated"/>
+								<xs:enumeration value="separate"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element minOccurs="0" name="BackupSystem" type="LocalReference">
+						<xs:annotation>
+							<xs:documentation>References the HeatingSystem that provides the backup for a separate backup.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
+					<xs:element minOccurs="0" name="BackupAFUE" type="AFUE"/>
+					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
+						<xs:annotation>
+							<xs:documentation>[Btuh]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature"
+						type="Temperature">
+						<xs:annotation>
+							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
+					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+						<xs:annotation>
+							<xs:documentation>[sq.ft.]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="AnnualCoolEfficiency" type="CoolingEfficiencyType"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualHeatEfficiency" minOccurs="0"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element minOccurs="0" ref="extension"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CoolingSystemInfoType">
+		<xs:complexContent>
+			<xs:extension base="HVACSystemInfo">
+				<xs:sequence>
+					<xs:element name="CoolingSystemType" type="CoolingSystemType" minOccurs="0"/>
+					<xs:element minOccurs="0" name="CoolingSystemFuel" type="FuelType"/>
+					<xs:element minOccurs="0" name="CoolingCapacity" type="xs:double">
+						<xs:annotation>
+							<xs:documentation>[Btuh]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+						<xs:annotation>
+							<xs:documentation>[sq.ft.]</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CoolingEfficiencyType">
+		<xs:sequence>
+			<xs:element name="Units" type="CoolingEfficiencyUnits"/>
+			<xs:element name="Value" type="Efficiency"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HeatingEfficiencyType">
+		<xs:sequence>
+			<xs:element name="Units" type="HeatingEfficiencyUnits">
+				<xs:annotation>
+					<xs:documentation>For AFUE and Percent enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Value" type="Efficiency"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HydronicDistributionInfo">
+		<xs:sequence>
+			<xs:element name="FractionHydronicPipeInsulated" type="Fraction" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PipeRValue" type="RValue"/>
+			<xs:element name="HydronicDistributionType" type="HydronicDistributionType"
+				minOccurs="0"/>
+			<xs:element minOccurs="0" name="PumpandZoneValve">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="ValveCorrections" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>System Pump and Zone Valve Corrections made</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="ThermostaticRadiatorValves"
+							type="xs:boolean"/>
+						<xs:element minOccurs="0" name="VariableSpeedPump" type="xs:boolean"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AirDistributionInfo">
+		<xs:sequence>
+			<xs:element name="AirDistributionType" type="AirDistributionType" minOccurs="0"/>
+			<xs:element name="AirHandlerMotorType" type="AirHandlerMotorType" minOccurs="0"/>
+			<xs:element minOccurs="0" name="DuctLeakageMeasurement"
+				type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="xs:boolean"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
+						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
+						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
+						<xs:element minOccurs="0" name="DuctInsulationThickness"
+							type="LengthMeasurement">
+							<xs:annotation>
+								<xs:documentation>[in]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="DuctInsulationCondition"
+							type="InsulationCondition"/>
+						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>
+						<xs:element minOccurs="0" name="FractionDuctArea" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>If a DuctType of supply or return is specified above, this is the fraction of the supply or return duct area. If DuctType is omitted above, this is the fraction of the total duct area. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="DuctSurfaceArea" type="SurfaceArea">
+							<xs:annotation>
+								<xs:documentation>[sq.ft.]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters"
+				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Supply"
+							type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Return"
+							type="TotalExternalStaticPressureMeasurement"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="BuildingSystemIdentifiers">
+		<xs:annotation>
+			<xs:documentation>HPXML records may contain data about an individual, either a person, or a business.  This element contains the root elements for individual identifier values between a sending and a receiving system.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="SystemIdentifiersInfo"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Associations" type="AssociationsType"> </xs:element>
+	<xs:element name="SystemIdentifiersInfo" type="SystemIdentifiersInfoType">
+		<xs:annotation>
+			<xs:documentation>System identifiers contain type codes and an identifier for both a sending and a receiving system.  These fields are needed to be able to transmit data between two systems, and have it identified in the two systems.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="IncentiveDetailsType">
+		<xs:sequence>
+			<xs:element name="IncentiveType" type="SystemIdentifiersInfoType"/>
+			<xs:element name="FundingSourceCode" type="FundingSourceCode" minOccurs="0"/>
+			<xs:element name="FundingSourceName" type="FundingSourceName" minOccurs="0"/>
+			<xs:element name="IncentiveAmount" type="IncentiveAmount" minOccurs="0"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BuildingDetailsType">
+		<xs:sequence>
+			<xs:element name="BuildingSummary" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Overall characterization of building for descriptive, rather than modeling purposes</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Site">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="SiteType" type="SiteType"/>
+									<xs:element minOccurs="0" name="Surroundings"
+										type="Surroundings">
+										<xs:annotation>
+											<xs:documentation>If the building is attached to other units in the horizontal plane.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="VerticalSurroundings"
+										type="VerticalSurroundings">
+										<xs:annotation>
+											<xs:documentation>If the building is attached to other units on the vertical plane.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ShieldingofHome" type="ShieldingofHome"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="OrientationOfFrontOfHome"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome"
+										type="AzimuthType"/>
+									<xs:element minOccurs="0" name="PublicTransportation">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="DistanceFromSubway"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="DistanceFromBus"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="DistanceFromTrain"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="WalkingScore"
+										type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScoreSource"
+										type="xs:string"/>
+									<xs:element minOccurs="0" name="FuelTypesAvailable">
+										<xs:annotation>
+											<xs:documentation>Fuels available on site via utility lines/pipes or delivery.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element maxOccurs="unbounded" name="Fuel"
+												type="FuelType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="BuildingOccupancy">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="HouseholdType"
+										type="HouseholdType"/>
+									<xs:element minOccurs="0" name="YearOccupied" type="Year">
+										<xs:annotation>
+											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="ResidentPopulationType"
+										type="ResidentPopulationType"/>
+									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
+									<xs:element name="NumberofResidents" type="PeopleCount"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults"
+										type="PeopleCount">
+										<xs:annotation>
+											<xs:documentation>18 or older</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofChildren"
+										type="IntegerGreaterThanOrEqualToZero">
+										<xs:annotation>
+											<xs:documentation>less than 18 years old</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="PubliclySubsidized"
+										type="xs:boolean"/>
+									<xs:element minOccurs="0" name="LowIncome" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="OccupantIncomeRange"
+										type="FractionGreaterThanOne">
+										<xs:annotation>
+											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits"
+										type="OccupantIncomeRangeUnits">
+										<xs:annotation>
+											<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation"
+										type="EducationLevels"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="BuildingConstruction">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
+									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated"
+										type="KnownOrEstimated"/>
+									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
+									<xs:element name="ResidentialFacilityType"
+										type="ResidentialFacilityType" minOccurs="0"/>
+									<xs:element minOccurs="0" name="PassiveSolar" type="xs:boolean">
+										<xs:annotation>
+											<xs:documentation>Passive solar design—also known as climatic design—involves using a building's windows, walls, and floors to collect, store, and distribute solar energy in the form of heat in the winter and reject solar heat in the summer. (source: http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="BuildingHeight"
+										type="LengthMeasurement">
+										<xs:annotation>
+											<xs:documentation>[ft] height of building</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofUnits"
+										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="NumberofFloors"
+										type="NumberOfFloorsType">
+										<xs:annotation>
+											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofConditionedFloors"
+										type="NumberOfFloorsType">
+										<xs:annotation>
+											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0"
+										name="NumberofConditionedFloorsAboveGrade"
+										type="NumberOfFloorsType">
+										<xs:annotation>
+											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="AverageCeilingHeight" type="LengthMeasurement"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="FloorToFloorHeight"
+										type="LengthMeasurement">
+										<xs:annotation>
+											<xs:documentation>[ft] distance between floors</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofRooms"
+										type="IntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms"
+										type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms"
+										type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms"
+										type="IntegerGreaterThanZero">
+										<xs:annotation>
+											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="BuildingFootprintArea"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="FootprintShape"
+										type="FootprintShape"/>
+									<xs:element minOccurs="0" name="GrossFloorArea"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]
+Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including basements, mezzanine and intermediate‐floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken from the exterior faces of exterior walls OR from the centerline of walls separating buildings, OR from the centerline of walls separating spaces. Excludes non‐enclosed (or non‐enclosable) roofed‐over areas such as exterior covered walkways, porches, terraces or steps, roof overhangs, and similar features. Excludes air shafts, pipe trenches, and chimneys. Excludes floor area dedicated to the parking and circulation of motor vehicles.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NetFloorArea" type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]
+The floor area of an occupiable space defined by the inside surfaces of its walls but excluding shafts, column enclosures, and other permanently enclosed, inaccessible, and unoccupiable areas. Obstructions in the space such as furnishings, display or storage racks, and other obstructions, whether temporary or permanent, may not be deducted from the space are considered to be part of the net occupiable area.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ConditionedFloorArea" type="SurfaceArea"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]
+All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless of HVAC configuration.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="FinishedFloorArea"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="NumberofStoriesAboveGrade"
+										type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]
+The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not enclosed such as open floors, covered ways and balconies.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HeatedFloorArea"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]
+The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not enclosed such as open floors, covered ways and balconies.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="UnconditionedFloorArea"
+										type="SurfaceArea">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.]
+An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an attached garage on a house or a vestibule with no thermal comfort criteria). Spaces that are ventilated only to maintain air quality are considered unconditioned spaces (such as a parking garage with no thermal comfort criteria).</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="BuildingVolume" type="Volume">
+										<xs:annotation>
+											<xs:documentation>[cu.ft.]
+A volume of a building surrounded by solid surfaces such as walls, roofs, floors, fenestration, and doors where the total opening area to the outside can be reduced to less than 1% of the Gross Interior Floor Area of the space. Spaces that are temporarily enclosed such as patios enclosed with tenting are not considered Enclosed Spaces for annual building analysis. These spaces should be treated as exterior to the building.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ConditionedBuildingVolume" type="Volume"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[cu.ft.]
+Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the Gross Conditioned Floor Area times the height from the top surface of the finished floor to the top surface of the finished floor separating levels of the building or to the inside surface of the roof for the top floor. The volume of spaces that have nonvertical walls or nonhorizontal ceilings of floors should be calculated separately to properly account for the non-rectangular geometry. This metric does include the volume of floor or ceiling return air plenums.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="FoundationType" minOccurs="0"
+										type="FoundationType">
+										<xs:annotation>
+											<xs:documentation>Primary foundation type of building</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="AtticType" type="AtticType" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Primary attic type of building</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="AverageAtticRValue" type="RValue"
+										minOccurs="0"/>
+									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="RValue"
+										minOccurs="0"/>
+									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
+									<xs:element minOccurs="0" name="GaragePresent" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="GarageLocation"
+										type="GarageLocation"/>
+									<xs:element minOccurs="0" name="SpaceAboveGarage"
+										type="SpaceAboveGarage"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="EnergyScore" type="EnergyScoreType"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AnnualEnergyUse" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
+										maxOccurs="unbounded"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ClimateandRiskZones" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="ClimateZoneDOE" type="ClimateZoneDOE" minOccurs="0"/>
+						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"/>
+						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
+						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
+						<xs:element name="HurricaneZone" type="xs:boolean" minOccurs="0"/>
+						<xs:element name="FloodZone" type="xs:boolean" minOccurs="0"/>
+						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation"
+							type="WeatherStation">
+							<xs:annotation>
+								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Zones" type="Zones"/>
+			<xs:element name="Enclosure" type="Enclosure" minOccurs="0"/>
+			<xs:element name="Systems" type="Systems" minOccurs="0"/>
+			<xs:element name="Appliances" type="Appliances" minOccurs="0"/>
+			<xs:element name="Lighting" type="Lighting" minOccurs="0"/>
+			<xs:element minOccurs="0" name="Pools" type="Pools"/>
+			<xs:element name="MiscLoads" type="MiscLoads" minOccurs="0"/>
+			<xs:element minOccurs="0" name="HealthAndSafety" type="HealthAndSafety"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ProjectDetailsType">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" name="ProjectSystemIdentifiers" type="RemoteReference"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
+			<xs:element name="ProgramName" type="ProgramName" minOccurs="0"/>
+			<xs:element maxOccurs="1" minOccurs="0" ref="ContractorSystemIdentifiers"/>
+			<xs:element minOccurs="0" name="ProgramSponsor" type="ProgramSponsor"/>
+			<xs:element minOccurs="0" name="CertifyingOrganization" type="CertifyingOrganization"/>
+			<xs:element minOccurs="0" name="CertifyingOrganizationURL" type="xs:string"/>
+			<xs:element minOccurs="0" name="YearCertified" type="Year"/>
+			<xs:element minOccurs="0" name="ProgramCertificate" maxOccurs="unbounded"
+				type="ProgramCertificate"/>
+			<xs:element minOccurs="0" name="EnergyStarHomeVersion" type="xs:string"/>
+			<xs:element name="ProjectType" type="ProjectType" minOccurs="0"/>
+			<xs:element name="Title" type="Title" minOccurs="0"/>
+			<xs:element minOccurs="0" ref="ProjectStatus"/>
+			<xs:element name="Notes" type="Notes" minOccurs="0"/>
+			<xs:element name="StartDate" type="StartDate" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Start date of project</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CompleteDateEstimated" type="CompleteDateEstimated" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Estimated completion date of project</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CompleteDateActual" type="CompleteDateActual" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Actual completion date of project</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="Hours" type="Hours">
+				<xs:annotation>
+					<xs:documentation>Amount of time spent by contractor on this stage of the project</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="FeeCost" type="Cost">
+				<xs:annotation>
+					<xs:documentation>Cost of any fees associated with the audit or other project activities</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="ProjectCost" type="TotalCostType">
+				<xs:annotation>
+					<xs:documentation>Cost of all work proposed or performed</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Incentives" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="Incentive"
+							type="IncentiveDetailsType"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
+				maxOccurs="2"/>
+			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
+			<xs:element minOccurs="0" name="Measures">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="Measure" type="MeasureDetailsType"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnergyScoreType">
+		<xs:sequence>
+			<xs:element name="ScoreType">
+				<xs:annotation>
+					<xs:documentation>The Home Energy Score is an asset rating for homes, developed and administered by the U.S. Department of Energy. After conducting a brief walk thru of a home, a qualified assessor calculates a home's score on a 10 point scale using a standard scoring tool, with 10 reflecting homes that use the least amount of energy assuming standard operating conditions (US DOE).
+
+The Home Energy Rating System (HERS) index is a measure of a home's energy efficiency. It can also be used to inspect and calculate a home's energy performance. The lower a home's HERS Index Score, the better its efficiency.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="RESNET HERS"/>
+						<xs:enumeration value="US DOE Home Energy Score"/>
+						<xs:enumeration value="other"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element minOccurs="0" name="OtherScoreType">
+				<xs:annotation>
+					<xs:documentation>Name of the score type if "other" is selected in ScoreType.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="ScoreDate" type="xs:date"/>
+			<xs:element name="Score" type="xs:integer"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TotalCostType">
+		<xs:sequence>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures"
+				minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures"
+				minOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MeasureDetailsType">
+		<xs:sequence>
+			<xs:element name="MeasureSystemIdentifiers">
+				<xs:annotation>
+					<xs:documentation>These are the system identifiers for a specific measure on a job</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" ref="SystemIdentifiersInfo"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
+			<xs:element name="MeasureCode" type="MeasureCode" minOccurs="0"/>
+			<xs:element name="MeasureDescription" type="MeasureDescription" minOccurs="0"/>
+			<xs:element minOccurs="0" name="Quantity">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Units" type="xs:string"/>
+						<xs:element name="Value" type="Quantity"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
+			<xs:element name="EstimatedLife" type="EstimatedLife" minOccurs="0"/>
+			<xs:element name="InstallationDate" type="InstallationDate" minOccurs="0"/>
+			<xs:element name="Cost" type="Cost" minOccurs="0"/>
+			<xs:element name="UnitPricingIndicator" type="xs:boolean" minOccurs="0"/>
+			<xs:element minOccurs="0" name="Incentives">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="Incentive"
+							type="IncentiveDetailsType"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="ResourceSavingsInfo">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="ResourcesSaved">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ResourceTypeCode" type="ResourceTypeCode"/>
+									<xs:element name="LoadProfile" type="LoadProfile" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>A load profile is created using measurements of a customer's electricity use at regular intervals, typically one hour or less, and provides an accurate representation of a customer's usage pattern over time.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Quantity" type="Quantity"/>
+									<xs:element name="AnnualAmount" type="AnnualAmount"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
+				maxOccurs="2"/>
+			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
+			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
+			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
+			<xs:element minOccurs="0" name="Status" type="ImprovementStatusType"/>
+			<xs:element minOccurs="0" name="NotInstalledReasonCode" type="xs:string"/>
+			<xs:element minOccurs="0" name="InstallingContractor" type="RemoteReference"/>
+			<xs:element minOccurs="0" name="QA">
+				<xs:annotation>
+					<xs:documentation>Quality assurance: The observation techniques and activities used externally by an organization to evaluate the effectiveness of their quality management system and to provide feedback that may result in quality improvements (BPI, 2006). </xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="QAStatus" type="TestResultType"/>
+						<xs:element name="QAComments" type="Notes"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="ReplacedComponents">
+				<xs:annotation>
+					<xs:documentation>or removed component</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="ReplacedComponent"
+							type="RemoteReference"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="InstalledComponent" type="RemoteReference"
+				maxOccurs="unbounded"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnergySavingsType">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="EnergySavingsType" type="MeasuredOrEstimated">
+				<xs:annotation>
+					<xs:documentation>Indicates whether it is measured energy savings or estimated energy savings.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="EnergySavingsReported" type="GrossOrNet"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings"
+				type="FuelSavingsType"/>
+			<xs:element name="DemandSavings" minOccurs="0" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>[kW] Demand savings from energy efficiency programs</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnualPercentReduction" type="xs:double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WaterSavingsType">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="WaterSavingsType" type="MeasuredOrEstimated"/>
+			<xs:element minOccurs="0" name="Units" type="waterUnitType"/>
+			<xs:element minOccurs="0" name="TotalSavings" type="xs:double"/>
+			<xs:element minOccurs="0" name="TotalDollarSavings" type="xs:double"/>
+			<xs:element minOccurs="0" name="PctReduction" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="RainBarrels" type="xs:double"/>
+			<xs:element minOccurs="0" name="ReclaimedWaterSystem" type="xs:boolean"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DuctLeakageMeasurementType">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="DuctType" type="DuctType"/>
+			<xs:element name="LeakinessObservedVisualInspection"
+				type="LeakinessObservedVisualInspection" minOccurs="0"/>
+			<xs:element name="DuctLeakageTestMethod" type="DuctLeakageTestMethod" minOccurs="0"/>
+			<xs:element minOccurs="0" name="DuctLeakage">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Units" type="DuctLeakageTestUnitofMeasure" minOccurs="0"/>
+						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
+						<xs:element minOccurs="0" name="TotalOrToOutside"
+							type="DuctLeakageTotalOrToOutside"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="SurfaceArea">
+				<xs:annotation>
+					<xs:documentation>The Leakage Area is defined in TECBLAST as the size of a sharp edged orifice which would leak at the same flow rate as the measured leakage, if the orifice were subjected to the Test Pressure.
+Leakage Area [sq in] = Duct System Leakage Rate [CFM] / (1.06 * (Test Pressure [Pa]) ^ 0.5)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ConsumptionInfoType">
+		<xs:sequence>
+			<xs:element name="UtilityID" type="RemoteReference"/>
+			<xs:element name="ConsumptionType" type="EnergyAndWaterUseTypeDescription"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
+			<xs:element maxOccurs="unbounded" name="ConsumptionDetail">
+				<xs:annotation>
+					<xs:documentation>Consumption records with enough granularity to be able to use smart meter data.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Consumption" type="xs:double">
+							<xs:annotation>
+								<xs:documentation>Negative number for renewable generation. Positive number for consumption.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="StartDateTime" type="xs:dateTime" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Date/time stamp in the ISO 8601 format when the usage measured began.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="EndDateTime" type="xs:dateTime" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Date/time stamp of the meter reading.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="ReadingType" type="MeterReadingType"/>
+						<xs:element name="ConsumptionCost" type="xs:double" minOccurs="0"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="MarginalRate" type="xs:double" minOccurs="0"/>
+			<xs:element minOccurs="0" name="BaseLoad" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling) (Krigger and Dorsi, 2009).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="BPI2400Inputs" type="BPI2400Inputs">
+				<xs:annotation>
+					<xs:documentation>The following fields are to support BPI-2400</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BPI2400Inputs">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="xs:date"/>
+			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="xs:date"/>
+			<xs:element minOccurs="0" name="CalibrationQualification"
+				type="BPI2400CalibrationQualification">
+				<xs:annotation>
+					<xs:documentation>This identifies which data quality requirements (if any) were met by the bills for the relevant energy source and therefore which calibration metrics (if any) are used to determine whether the calibrated model is accepted.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="CalibrationWeatherRegressionCVRMSE" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Detailed Calibration Weather Regression CV-RMSE. Eqn. 3.2.2.G.i  of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="WeatherNormalizedHeatingUsage" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Weather Normalized Annual Heating Usage</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="WeatherNormalizedCoolingUsage" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Weather Normalized Annual Cooling Usage</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="WeatherNormalizedBaseloadUsage" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Weather Normalized Annual Baseload Usage</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Eqn. 3.2.3.A.i  of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Eqn. 3.2.3.A.ii  of BPI-2400. In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError"
+				nillable="true" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError"
+				nillable="true" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError"
+				type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnergyAndWaterUseTypeDescription">
+		<xs:choice>
+			<xs:element name="Energy">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="FuelType" type="FuelType">
+							<xs:annotation>
+								<xs:documentation>Energy Type</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="UnitofMeasure" type="energyUnitType"/>
+						<xs:element minOccurs="0" name="MeteringConfiguration"
+							type="MeteringConfiguration">
+							<xs:annotation>
+								<xs:documentation>direct metering = tenants directly metered;
+master meter without sub-metering = tenants not sub metered;
+master meter with sub-metering = tenant sub-metered by building owner</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="EmissionsFactors">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="EmissionsFactor" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="EmissionType" type="EmissionType"/>
+												<xs:element name="EmissionUnits"
+												type="EmissionUnits"/>
+												<xs:element name="Emissions" type="xs:double"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="FuelInterruptibility"
+							type="FuelInterruptibility"/>
+						<xs:element minOccurs="0" name="SharedEnergySystem"
+							type="SharedEnergySystem"/>
+						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
+						<xs:element minOccurs="0" name="ReadingTimeZone" type="xs:string"/>
+						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="xs:double">
+							<xs:annotation>
+								<xs:documentation>[$/energy unit] The cost of providing an additional unit of output</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="EnergyUseIntensity" type="xs:double">
+							<xs:annotation>
+								<xs:documentation>[kBtu/ft^2] Energy use intensity (EUI) is a unit of measurement that describes a building's energy use. EUI represents the energy consumed by a building relative to its size.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="PeakSeason" type="PeakSeason">
+							<xs:annotation>
+								<xs:documentation>Period during which electrical power is expected to be provided at a significantly higher than average supply level.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Water">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="WaterType" type="WaterType"/>
+						<xs:element name="UnitofMeasure" type="waterUnitType"/>
+						<xs:element minOccurs="0" name="MarginalWaterCostRate" type="xs:double"/>
+						<xs:element minOccurs="0" name="WaterUseIntensity">
+							<xs:annotation>
+								<xs:documentation>Water use intensity is defined as annual water use divided by total gross square footage of facility space reported in gallons per square foot (DOE, 2013). This element may also be reported as gallons, per day, per person.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Units" type="WaterUseIntensityUnits"/>
+									<xs:element name="Value" type="xs:double"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ModeledUsageType">
+		<xs:sequence>
+			<xs:element name="EnergyType" type="FuelType">
+				<xs:annotation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UnitofMeasure" type="energyUnitType"/>
+			<xs:element minOccurs="0" name="AnnualConsumption" type="xs:double"/>
+			<xs:element minOccurs="0" name="AnnualFuelCost" type="xs:double"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse"
+				type="EndUseInfoType"/>
+			<xs:element minOccurs="0" name="BaseLoad" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling) (Krigger and Dorsi, 2009).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="ElectricityDemandKW" type="xs:double"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StudProperties">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="Size" type="StudSize">
+				<xs:annotation>
+					<xs:documentation>Type of stud, joist, etc. (2x4, 2x6, etc)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="Spacing" type="LengthMeasurement">
+				<xs:annotation>
+					<xs:documentation>[in] Spacing on center</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="FramingFactor" type="Fraction"/>
+			<xs:element minOccurs="0" name="Material" type="StudMaterial"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TelephoneInfoType">
+		<xs:sequence>
+			<xs:element name="TelephoneType" type="TelephoneTypeCode" minOccurs="0"/>
+			<xs:element name="TelephoneNumber" type="TelephoneNumber"/>
+			<xs:element minOccurs="0" name="PreferredContactMethod" type="xs:boolean"/>
+			<xs:element name="TelephoneExtension" type="TelephoneExtension" minOccurs="0"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EmailInfoType">
+		<xs:sequence>
+			<xs:element name="EmailType" type="EmailTypeCode" minOccurs="0"/>
+			<xs:element name="EmailAddress" type="EmailAddress"/>
+			<xs:element minOccurs="0" name="PreferredContactMethod" type="xs:boolean"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BusinessInfoType">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element name="BusinessName" type="xs:string"/>
+			<xs:element name="BusinessType" type="BusinessType" minOccurs="0"/>
+			<xs:element name="BusinessSpecialization" type="BusinessSpecialization" minOccurs="0"/>
+			<xs:element name="Certification" type="BusinessCertification" minOccurs="0"
+				maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact"
+				type="BusinessContactInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo"
+				type="TelephoneInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BusinessContactInfoType">
+		<xs:sequence>
+			<xs:element name="ContactType" type="BusinessContactType" minOccurs="0"/>
+			<xs:element minOccurs="0" name="Person" type="IndividualInfo"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:group name="WindowInfo">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element name="Area" type="SurfaceArea" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[sq.ft.] Total window surface area for this group of windows</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero">
+				<xs:annotation>
+					<xs:documentation>Number of windows in the group</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[deg]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+			<xs:element name="FrameType" minOccurs="0">
+				<xs:complexType>
+					<xs:choice>
+						<xs:element name="Aluminum">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Composite">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Fiberglass">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Metal">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Vinyl">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Wood">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Other">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element minOccurs="0" name="Description"/>
+									<xs:element minOccurs="0" ref="extension"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="GlassLayers" type="GlassLayers"/>
+			<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
+			<xs:element minOccurs="0" name="GasFill" type="GasFill"/>
+			<xs:element name="Treatments" type="Treatments" minOccurs="0"/>
+			<xs:element name="Condition" type="WindowCondition" minOccurs="0"/>
+			<xs:element name="UFactor" type="UFactor" minOccurs="0"/>
+			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
+			<xs:element name="NFRCCertified" type="xs:boolean" minOccurs="0"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="WindowThirdPartyCertification"/>
+			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
+			<xs:element minOccurs="0" name="InteriorShading" type="InteriorShading"/>
+			<xs:element minOccurs="0" name="InteriorShadingFactor" type="Fraction"/>
+			<xs:element minOccurs="0" name="ExteriorShading" type="ExteriorShading"/>
+			<xs:element minOccurs="0" name="Overhangs">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Depth" type="LengthMeasurement">
+							<xs:annotation>
+								<xs:documentation>[in] Depth of overhang</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow"
+							type="LengthMeasurement">
+							<xs:annotation>
+								<xs:documentation>[in] Vertical distance from overhang to top of window</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow"
+							type="LengthMeasurement">
+							<xs:annotation>
+								<xs:documentation>[in] Vertical distance from overhang to bottom of window</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="WeatherStripping" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="Operable" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="MovableInsulationRValue" type="RValue">
+				<xs:annotation>
+					<xs:documentation>Rigid opaque foam panels (permanently installed or not) or cellular shades that provide insulation. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="AssociationsType">
+		<xs:all minOccurs="0">
+			<xs:element name="Job" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Measures" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Measure" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:attribute name="ID" type="xs:int" use="required"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="JobRole" type="JobRole" minOccurs="0"/>
+					</xs:sequence>
+					<xs:attribute name="ID" type="xs:int" use="required"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Locations" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Location" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="ID" type="xs:int" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Contractor" minOccurs="0">
+				<xs:complexType>
+					<xs:attribute name="ID" type="xs:int"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:all>
+	</xs:complexType>
+	<xs:complexType name="AirInfiltrationMeasurementType">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" name="Date" type="xs:date"/>
+			<xs:element minOccurs="0" name="BusinessConductingTest" type="RemoteReference"/>
+			<xs:element minOccurs="0" name="IndividualConductingTest" type="RemoteReference"/>
+			<xs:element minOccurs="0" name="OutsideTemperature" type="Temperature">
+				<xs:annotation>
+					<xs:documentation>[deg F]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
+			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement"
+				minOccurs="0"/>
+			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
+			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[Pa] with respect to outside</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FanPressure" type="FanPressure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[Pa]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FanRingUsed" type="FanRingUsed" minOccurs="0"/>
+			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
+			<xs:element minOccurs="0" name="BuildingAirLeakage">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
+						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>[sq.in.] The Effective Leakage Area is defined as the area of a special nozzle-shaped hole (similar to the inlet of a blower door fan) that would leak the same amount of air as the building does at a pressure of 4 Pascals.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MoistureControlInfoType">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element name="ExteriorLocationsWaterIntrusionorDamage"
+				type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InteriorLocationsofWaterLeaksorDamage"
+				type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FoundationType">
+		<xs:choice>
+			<xs:element name="Basement">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Finished" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Crawlspace">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Vented" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SlabOnGrade">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Garage">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="AboveApartment">
+				<xs:annotation>
+					<xs:documentation>for single unit retrofits in multifamily properties</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Combination">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Ambient">
+				<xs:annotation>
+					<xs:documentation>For use on sections of the house that are cantilevered or over ambient (outdoor) conditions for some other reason. </xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="RubbleStone">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="WallType">
+		<xs:annotation>
+			<xs:documentation>Wall type enumerations are further explained at
+https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="WoodStud">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing"
+							type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Sheathing insulation should be specified in the Insulation element as well.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="OptimumValueEngineering" type="xs:boolean">
+							<xs:annotation>
+								<xs:documentation>Please specify stud spacing and framing factor in the appropriate places as well.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="DoubleWoodStud">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Staggered" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ConcreteMasonryUnit">
+				<xs:annotation>
+					<xs:documentation>Concrete Masonry Unit</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="StructurallyInsulatedPanel">
+				<xs:annotation>
+					<xs:documentation>Structurally Insulated Panel</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="InsulatedConcreteForms">
+				<xs:annotation>
+					<xs:documentation>Insulated Concrete Forms</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SteelFrame">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SolidConcrete">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="StructuralBrick">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="StrawBale">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Stone">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="LogWall">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="HVACControlType">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" ref="AttachedToZone"/>
+			<xs:element name="ControlType" type="ThermostatType" minOccurs="0"/>
+			<xs:element name="SetpointTempHeatingSeason" type="Temperature" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[deg F]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SetbackTempHeatingSeason" type="Temperature" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[deg F]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TotalSetbackHoursperWeekHeating" type="Hours" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[hours]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SetupTempCoolingSeason" type="Temperature" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[deg F]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SetpointTempCoolingSeason" type="Temperature" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[deg F]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TotalSetupHoursperWeekCooling" type="Hours" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[hours]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="HotWaterResetControl" type="HotWaterResetControl"/>
+			<xs:element minOccurs="0" name="HeatLowered" type="HVACControlTypeAdjustments"/>
+			<xs:element minOccurs="0" name="ACAdjusted" type="HVACControlTypeAdjustments"/>
+			<xs:element minOccurs="0" name="FractionThermostaticRadiatorValves" type="Fraction">
+				<xs:annotation>
+					<xs:documentation>Fraction of rooms controlled by thermostatic radiator valves</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="FractionElectronicZoneValves" type="Fraction">
+				<xs:annotation>
+					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0"
+				maxOccurs="unbounded"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HVACControlTypeAdjustments">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="Day" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="Night" type="xs:boolean"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MoistureControlImprovementInfo">
+		<xs:sequence>
+			<xs:element name="VaporRetardersInstalled" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="GuttersInstalledorRepaired" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FlashingInstalledorRepaired" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FoundationGradingImproved" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="OtherMeasuresImplementedDescription" type="xs:string" minOccurs="0"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HVACDistributionImprovementInfo">
+		<xs:sequence>
+			<xs:element name="DuctSystemSealed" type="xs:boolean" minOccurs="0"/>
+			<xs:element minOccurs="0" name="DuctSystemSealedYearMonth" type="xs:gYearMonth">
+				<xs:annotation>
+					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="xs:boolean"
+				minOccurs="0"/>
+			<xs:element name="DuctSystemReplaced" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="xs:boolean" minOccurs="0"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HVACMaintenance">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="TuneAndRepair" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="TuneAndRepairYearMonth" type="xs:gYearMonth">
+				<xs:annotation>
+					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced"
+				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"
+				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="AirFilter">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="Size">
+							<xs:annotation>
+								<xs:documentation>Width x Length x Thickness</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Width">
+										<xs:annotation>
+											<xs:documentation>[in]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Length">
+										<xs:annotation>
+											<xs:documentation>[in]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Thickness">
+										<xs:annotation>
+											<xs:documentation>[in]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="MERVRating" type="MERV">
+							<xs:annotation>
+								<xs:documentation>Minimum efficiency reporting value, commonly known as MERV rating, is a measurement scale designed in 1987 by the American Society of Heating, Refrigerating and Air-Conditioning Engineers (ASHRAE) to rate the effectiveness of air filters.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LastReplaced" type="xs:gYearMonth">
+							<xs:annotation>
+								<xs:documentation>The Year and Month the filter was last replacced.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WaterHeaterImprovementInfo">
+		<xs:sequence>
+			<xs:element name="JacketInstalledIndicator" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem"
+				minOccurs="0"/>
+			<xs:element name="RepairsDescription" type="xs:string" minOccurs="0"
+				maxOccurs="unbounded"/>
+			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
+			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>[ft]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SystemReplaced" type="xs:boolean" minOccurs="0"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="VentilationImprovementInfo">
+		<xs:sequence>
+			<xs:element name="GarageDuctsandAirHandlersAirSealed" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MechanicalVentilationInstalled" type="xs:boolean" minOccurs="0"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Building">
+		<xs:sequence>
+			<xs:element name="BuildingID" type="SystemIdentifiersInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
+			<xs:element minOccurs="0" name="CustomerID" type="RemoteReference"/>
+			<xs:element minOccurs="0" name="Site">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SiteID" type="SystemIdentifiersInfoType"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
+						<xs:element name="Address" type="AddressInformation"/>
+						<xs:element minOccurs="0" name="SchoolDistrict" type="xs:string"/>
+						<xs:element minOccurs="0" name="eGridRegion" type="eGridRegions"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="ContractorID" type="RemoteReference"/>
+			<xs:element ref="ProjectStatus"/>
+			<xs:element name="BuildingDetails" type="BuildingDetailsType">
+				<xs:annotation>
+					<xs:documentation>Building Description</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="ModeledUsages">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="WeatherStation" type="LocalReference">
+							<xs:annotation>
+								<xs:documentation>Indicates which weather station is used for the modeling. It's a reference that points to Building/BuildingDetails/ClimateAndRiskZones/WeatherStation</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" name="ModeledUsage"
+							type="ModeledUsageType"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Project">
+		<xs:sequence>
+			<xs:element name="BuildingID" type="RemoteReference"/>
+			<xs:element minOccurs="0" name="ProjectID" type="SystemIdentifiersInfoType"/>
+			<xs:element name="ProjectDetails" type="ProjectDetailsType"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Contractor">
+		<xs:sequence>
+			<xs:element name="ContractorDetails" type="ContractorType"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Customer">
+		<xs:sequence>
+			<xs:element name="CustomerDetails">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Person" type="IndividualInfo"/>
+						<xs:element minOccurs="0" name="MailingAddress" type="AddressInformation">
+							<xs:annotation>
+								<xs:documentation>If different from building street address.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="OtherContact">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Person" type="IndividualInfo"/>
+						<xs:element name="Address" type="AddressInformation"> </xs:element>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Utility">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="UtilitiesorFuelProviders">
+				<xs:annotation>
+					<xs:documentation>Utility company information</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" ref="UtilityFuelProvider"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Consumption">
+		<xs:sequence>
+			<xs:element name="BuildingID" type="RemoteReference"/>
+			<xs:element name="CustomerID" type="RemoteReference"/>
+			<xs:element minOccurs="0" name="ConsumptionDetails">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="ConsumptionInfo"
+							type="ConsumptionInfoType"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WeatherStation">
+		<xs:sequence>
+			<xs:element ref="SystemIdentifiersInfo"/>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element minOccurs="0" name="City" nillable="true" type="xs:string"/>
+			<xs:element minOccurs="0" name="State" type="StateCode"/>
+			<xs:element minOccurs="0" name="WBAN" type="xs:string"/>
+			<xs:element minOccurs="0" name="WMO" type="xs:string"/>
+			<xs:element minOccurs="0" name="Type" type="WeatherStationType"/>
+			<xs:element minOccurs="0" name="Use" nillable="true" type="WeatherStationUse"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PipeInsulationType">
+		<xs:sequence>
+			<xs:element name="PipeRValue" type="RValue" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PipeLengthInsulated" type="LengthMeasurement">
+				<xs:annotation>
+					<xs:documentation>[ft]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FractionPipeInsulation" type="Fraction" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Fraction of total pipe insulated</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TotalExternalStaticPressureMeasurement">
+		<xs:sequence>
+			<xs:element name="StaticPressure" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>[Pa] positive for supply side measurements, negative for return side.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="MeasurementLocation"
+				type="AirHandlerStaticPressureMeasurementLocation"/>
+			<xs:element minOccurs="0" name="LocationDescription" type="xs:string"/>
+			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WallAndFloorFurnace">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="SealedCombustion" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="AtmosphericBurner" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="PowerBurner" type="xs:boolean"/>
+			<xs:element minOccurs="0" ref="extension"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="ExternalResource">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="URL" type="xs:anyURI"/>
+				<xs:element name="Type">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="photo"/>
+							<xs:enumeration value="illustration"/>
+							<xs:enumeration value="document"/>
+							<xs:enumeration value="spreadsheet"/>
+							<xs:enumeration value="website"/>
+							<xs:enumeration value="other"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="Description" type="xs:string"/>
+				<xs:element minOccurs="0" ref="extension"/>
+			</xs:sequence>
+			<xs:attribute name="id" use="required"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/hescorehpxml/schemas/hpxml-2.3.0/HPXML.xsd
+++ b/hescorehpxml/schemas/hpxml-2.3.0/HPXML.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2014/6"
+    targetNamespace="http://hpxmlonline.com/2014/6" elementFormDefault="qualified" version="2.3">
+    <xs:include schemaLocation="BaseElements.xsd"/>
+
+
+    <xs:element name="HPXML">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="XMLTransactionHeaderInformation"/>
+                <xs:element ref="SoftwareInfo"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Contractor" nillable="true"
+                    type="Contractor"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Customer" nillable="true"
+                    type="Customer"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Building" nillable="true"
+                    type="Building"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Project" nillable="true"
+                    type="Project"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Utility" nillable="true"
+                    type="Utility"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Consumption" nillable="true"
+                    type="Consumption"/>
+            </xs:sequence>
+            <xs:attribute name="schemaVersion" type="schemaVersionType" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/hescorehpxml/schemas/hpxml-2.3.0/HPXMLDataTypes.xsd
+++ b/hescorehpxml/schemas/hpxml-2.3.0/HPXMLDataTypes.xsd
@@ -1,0 +1,2110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2014/6"
+	targetNamespace="http://hpxmlonline.com/2014/6" elementFormDefault="qualified" version="2.3">
+	<!-- Value Lists -->
+	<!--Address Information Below-->
+	<xs:simpleType name="schemaVersionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="2.0"/>
+			<xs:enumeration value="2.1"/>
+			<xs:enumeration value="2.2"/>
+			<xs:enumeration value="2.2.1"/>
+			<xs:enumeration value="2.3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AddressTypeCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="street"/>
+			<xs:enumeration value="mailing"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StateCode">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="ZipCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{5}(-[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="USPSBarCode">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<!--Name Information Below-->
+	<xs:simpleType name="PrefixName">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="SuffixName">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="IndividualType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="owner-occupant"/>
+			<xs:enumeration value="owner-non-occupant"/>
+			<xs:enumeration value="property manager"/>
+			<xs:enumeration value="real estate agent"/>
+			<xs:enumeration value="tenant"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BusinessCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BPI"/>
+			<xs:enumeration value="RESNET"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Telephone Information Below-->
+	<xs:simpleType name="TelephoneTypeCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="day"/>
+			<xs:enumeration value="evening"/>
+			<xs:enumeration value="mobile"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TelephoneNumber">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="TelephoneExtension">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<!--Email Information Below-->
+	<xs:simpleType name="EmailTypeCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="personal"/>
+			<xs:enumeration value="work"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EmailAddress">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<!--System Identifiers Below-->
+	<xs:simpleType name="SendingSystemIdentifierType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="SendingSystemIdentifierValue">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="ReceivingSystemIdentifierType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="ReceivingSystemIdentifierValue">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<!--XMLTransaction Header Information Below-->
+	<xs:simpleType name="XMLType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="XMLGeneratedBy">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="CreatedDateAndTime">
+		<xs:restriction base="xs:dateTime"/>
+	</xs:simpleType>
+	<!--Utility Information Below-->
+	<!--Misc Data Fields Below-->
+	<!--Air Infiltration Below-->
+	<xs:simpleType name="BuildingLeakiness">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="very tight"/>
+			<xs:enumeration value="tight"/>
+			<xs:enumeration value="average"/>
+			<xs:enumeration value="leaky"/>
+			<xs:enumeration value="very leaky"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WindConditions">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="windy"/>
+			<xs:enumeration value="normal"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BuildingAirLeakage">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BuildingAirLeakageUnit">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CFM"/>
+			<xs:enumeration value="CFMnatural"/>
+			<xs:enumeration value="ACH"/>
+			<xs:enumeration value="ACHnatural"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FanPressure">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<xs:simpleType name="FanRingUsed">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="open"/>
+			<xs:enumeration value="A"/>
+			<xs:enumeration value="B"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TestDate">
+		<xs:restriction base="xs:dateTime"/>
+	</xs:simpleType>
+	<xs:simpleType name="TestInorOut">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="test in"/>
+			<xs:enumeration value="test out"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TypeofBlowerDoorTest">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="pressurization"/>
+			<xs:enumeration value="depressurization"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HousePressure">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TypeofInfiltrationMeasurement">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="blower door"/>
+			<xs:enumeration value="tracer gas"/>
+			<xs:enumeration value="estimate"/>
+			<xs:enumeration value="checklist"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Climate and Risk Zones-->
+	<xs:simpleType name="ClimateZoneDOE">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="subarctic"/>
+			<xs:enumeration value="marine"/>
+			<xs:enumeration value="hot-dry"/>
+			<xs:enumeration value="mixed-dry"/>
+			<xs:enumeration value="hot-humid"/>
+			<xs:enumeration value="mixed-humid"/>
+			<xs:enumeration value="cold"/>
+			<xs:enumeration value="very cold"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IECCYear">
+		<xs:restriction base="xs:integer">
+			<xs:enumeration value="2012"/>
+			<xs:enumeration value="2009"/>
+			<xs:enumeration value="2006"/>
+			<xs:enumeration value="2003"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClimateZoneIECC">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1A"/>
+			<xs:enumeration value="1B"/>
+			<xs:enumeration value="1C"/>
+			<xs:enumeration value="2A"/>
+			<xs:enumeration value="2B"/>
+			<xs:enumeration value="2C"/>
+			<xs:enumeration value="3A"/>
+			<xs:enumeration value="3B"/>
+			<xs:enumeration value="3C"/>
+			<xs:enumeration value="4A"/>
+			<xs:enumeration value="4B"/>
+			<xs:enumeration value="4C"/>
+			<xs:enumeration value="5A"/>
+			<xs:enumeration value="5B"/>
+			<xs:enumeration value="5C"/>
+			<xs:enumeration value="6A"/>
+			<xs:enumeration value="6B"/>
+			<xs:enumeration value="6C"/>
+			<xs:enumeration value="7"/>
+			<xs:enumeration value="8"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EarthquakeZone">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="RadonZone">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TermiteZone">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="none to slight"/>
+			<xs:enumeration value="slight to moderate"/>
+			<xs:enumeration value="moderate to heavy"/>
+			<xs:enumeration value="very heavy"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Construction Below-->
+	<xs:simpleType name="ResidentialFacilityType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="single-family detached"/>
+			<xs:enumeration value="single-family attached"/>
+			<xs:enumeration value="manufactured home"/>
+			<xs:enumeration value="2-4 unit building"/>
+			<xs:enumeration value="5+ unit building"/>
+			<xs:enumeration value="multi-family - uncategorized"/>
+			<xs:enumeration value="multi-family - town homes"/>
+			<xs:enumeration value="multi-family - condos"/>
+			<xs:enumeration value="apartment unit"/>
+			<xs:enumeration value="studio unit"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EducationLevels">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="no high school"/>
+			<xs:enumeration value="some high school"/>
+			<xs:enumeration value="high school graduate"/>
+			<xs:enumeration value="some college"/>
+			<xs:enumeration value="vocational/technical/associates degree"/>
+			<xs:enumeration value="bachelor's degree"/>
+			<xs:enumeration value="some post graduate "/>
+			<xs:enumeration value="master's degree"/>
+			<xs:enumeration value="professional degree"/>
+			<xs:enumeration value="doctoral degree"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FootprintShape">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="rectangular"/>
+			<xs:enumeration value="square"/>
+			<xs:enumeration value="circular"/>
+			<xs:enumeration value="L-shaped"/>
+			<xs:enumeration value="U-shaped"/>
+			<xs:enumeration value="I-shaped"/>
+			<xs:enumeration value="V-shaped"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="OrientationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="north"/>
+			<xs:enumeration value="northwest"/>
+			<xs:enumeration value="west"/>
+			<xs:enumeration value="southwest"/>
+			<xs:enumeration value="south"/>
+			<xs:enumeration value="southeast"/>
+			<xs:enumeration value="east"/>
+			<xs:enumeration value="northeast"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NumberOfFloorsType">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IntegerGreaterThanZero">
+		<xs:restriction base="xs:integer">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IntegerGreaterThanOrEqualToZero">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SiteType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="rural"/>
+			<xs:enumeration value="suburban"/>
+			<xs:enumeration value="urban"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Surroundings">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="stand-alone"/>
+			<xs:enumeration value="attached on one side"/>
+			<xs:enumeration value="attached on two sides"/>
+			<xs:enumeration value="attached on three sides"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VerticalSurroundings">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="unit above"/>
+			<xs:enumeration value="unit below"/>
+			<xs:enumeration value="unit above and below"/>
+			<xs:enumeration value="no units above or below"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ShieldingofHome">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="well-shielded"/>
+			<xs:enumeration value="normal"/>
+			<xs:enumeration value="exposed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GarageLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="first floor"/>
+			<xs:enumeration value="detached"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpaceAboveGarage">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="conditioned area"/>
+			<xs:enumeration value="unconditioned attic"/>
+			<xs:enumeration value="crawlspace"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HouseholdType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="family household"/>
+			<xs:enumeration value="married couple, no children"/>
+			<xs:enumeration value="male household, no spouse"/>
+			<xs:enumeration value="female household, no spouse"/>
+			<xs:enumeration value="nonfamily household"/>
+			<xs:enumeration value="single male"/>
+			<xs:enumeration value="single female"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ResidentPopulationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="no specific resident population"/>
+			<xs:enumeration value="student"/>
+			<xs:enumeration value="military"/>
+			<xs:enumeration value="senior"/>
+			<xs:enumeration value="special accessibility needs"/>
+			<xs:enumeration value="young children"/>
+			<xs:enumeration value="at risk"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Occupancy">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="owner-occupied"/>
+			<xs:enumeration value="renter-occupied"/>
+			<xs:enumeration value="owner-and-renter-occupied"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="OccupantIncomeRangeUnits">
+		<xs:annotation>
+			<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="% area median income"/>
+			<xs:enumeration value="% federal poverty level"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Year">
+		<xs:restriction base="xs:integer"/>
+	</xs:simpleType>
+	<!-- Make sure to update FuelType with changes to this list as well. -->
+	<xs:simpleType name="ConsumptionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="electricity"/>
+			<xs:enumeration value="renewable electricity"/>
+			<xs:enumeration value="natural gas"/>
+			<xs:enumeration value="renewable natural gas"/>
+			<xs:enumeration value="fuel oil"/>
+			<xs:enumeration value="fuel oil 1"/>
+			<xs:enumeration value="fuel oil 2"/>
+			<xs:enumeration value="fuel oil 4"/>
+			<xs:enumeration value="fuel oil 5/6"/>
+			<xs:enumeration value="district steam"/>
+			<xs:enumeration value="district hot water"/>
+			<xs:enumeration value="district chilled water"/>
+			<xs:enumeration value="solar hot water"/>
+			<xs:enumeration value="propane"/>
+			<xs:enumeration value="kerosene"/>
+			<xs:enumeration value="diesel"/>
+			<xs:enumeration value="anthracite coal"/>
+			<xs:enumeration value="bituminous coal"/>
+			<xs:enumeration value="coke"/>
+			<xs:enumeration value="wood"/>
+			<xs:enumeration value="wood pellets"/>
+			<xs:enumeration value="combination"/>
+			<xs:enumeration value="water"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MeteringConfiguration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="direct metering"/>
+			<xs:enumeration value="master meter without sub-metering"/>
+			<xs:enumeration value="master meter with sub-metering"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EmissionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CO2"/>
+			<xs:enumeration value="methane"/>
+			<xs:enumeration value="N2O"/>
+			<xs:enumeration value="CO2 equivalent"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EmissionUnits">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="kg"/>
+			<xs:enumeration value="ton"/>
+			<xs:enumeration value="metric ton"/>
+			<xs:enumeration value="pound"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FuelInterruptibility">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="interruptible"/>
+			<xs:enumeration value="firm"/>
+			<xs:enumeration value="na"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SharedEnergySystem">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="yes"/>
+			<xs:enumeration value="no"/>
+			<xs:enumeration value="common meter"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IntervalType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="15-minute"/>
+			<xs:enumeration value="hourly"/>
+			<xs:enumeration value="daily"/>
+			<xs:enumeration value="monthly"/>
+			<xs:enumeration value="annual"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PeakSeason">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="summer"/>
+			<xs:enumeration value="winter"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="COReading">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<xs:simpleType name="RadonTestTypes">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="activated charcoal absorption"/>
+			<xs:enumeration value="alpha-track detectors"/>
+			<xs:enumeration value="unfiltered track detection"/>
+			<xs:enumeration value="short term electret ion chamber"/>
+			<xs:enumeration value="long term electret ion chamber"/>
+			<xs:enumeration value="continuous radon monitoring"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RadonTestLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="kitchen"/>
+			<xs:enumeration value="crawlspace"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="bedroom"/>
+			<xs:enumeration value="living room"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Make sure to update ConsumptionType with changes to this list as well. -->
+	<xs:simpleType name="FuelType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="electricity"/>
+			<xs:enumeration value="renewable electricity"/>
+			<xs:enumeration value="natural gas"/>
+			<xs:enumeration value="renewable natural gas"/>
+			<xs:enumeration value="fuel oil"/>
+			<xs:enumeration value="fuel oil 1"/>
+			<xs:enumeration value="fuel oil 2"/>
+			<xs:enumeration value="fuel oil 4"/>
+			<xs:enumeration value="fuel oil 5/6"/>
+			<xs:enumeration value="district steam"/>
+			<xs:enumeration value="district hot water"/>
+			<xs:enumeration value="district chilled water"/>
+			<xs:enumeration value="solar hot water"/>
+			<xs:enumeration value="propane"/>
+			<xs:enumeration value="kerosene"/>
+			<xs:enumeration value="diesel"/>
+			<xs:enumeration value="anthracite coal"/>
+			<xs:enumeration value="bituminous coal"/>
+			<xs:enumeration value="coke"/>
+			<xs:enumeration value="wood"/>
+			<xs:enumeration value="wood pellets"/>
+			<xs:enumeration value="combination"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Other Health and Safety Below-->
+	<!--Standard Measure Fields Below-->
+	<xs:simpleType name="EventType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="audit"/>
+			<xs:enumeration value="proposed workscope"/>
+			<xs:enumeration value="approved workscope"/>
+			<xs:enumeration value="construction-period testing/daily test out"/>
+			<xs:enumeration value="job completion testing/final inspection"/>
+			<xs:enumeration value="quality assurance/monitoring"/>
+			<xs:enumeration value="preconstruction"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Air Sealing Below-->
+	<!--Doors Below-->
+	<xs:simpleType name="AtticComponentsAirSealed">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="attic floor"/>
+			<xs:enumeration value="top plates"/>
+			<xs:enumeration value="kneewall transitions"/>
+			<xs:enumeration value="plumbing wet walls"/>
+			<xs:enumeration value="chimney/flue chases"/>
+			<xs:enumeration value="recessed lights"/>
+			<xs:enumeration value="attic access"/>
+			<xs:enumeration value="dropped soffit"/>
+			<xs:enumeration value="attic level transitions"/>
+			<xs:enumeration value="mechanical chases"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BasementCrawlspaceComponentsAirSealed">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="plumbing penetrations"/>
+			<xs:enumeration value="access"/>
+			<xs:enumeration value="wiring penetrations"/>
+			<xs:enumeration value="chimney/flue chase"/>
+			<xs:enumeration value="mechanical chases"/>
+			<xs:enumeration value="rim joists"/>
+			<xs:enumeration value="windows and door"/>
+			<xs:enumeration value="foundation service penetrations"/>
+			<xs:enumeration value="cantilevers"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LivingSpaceComponentsAirSealed">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="home-garage connection"/>
+			<xs:enumeration value="rim joists"/>
+			<xs:enumeration value="baseboards"/>
+			<xs:enumeration value="windows and door"/>
+			<xs:enumeration value="plumbing penetrations"/>
+			<xs:enumeration value="hvac registers"/>
+			<xs:enumeration value="interior sheating voids"/>
+			<xs:enumeration value="cantilevers"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FoundationWallType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="solid concrete"/>
+			<xs:enumeration value="concrete block"/>
+			<xs:enumeration value="concrete block foam core"/>
+			<xs:enumeration value="concrete block vermiculite core"/>
+			<xs:enumeration value="double brick"/>
+			<xs:enumeration value="wood"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AdjacentTo">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ambient"/>
+			<xs:enumeration value="garage"/>
+			<xs:enumeration value="attic"/>
+			<xs:enumeration value="crawlspace"/>
+			<xs:enumeration value="ground"/>
+			<xs:enumeration value="living space"/>
+			<xs:enumeration value="unconditioned basement"/>
+			<xs:enumeration value="other housing unit"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StudSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="2x2"/>
+			<xs:enumeration value="2x3"/>
+			<xs:enumeration value="2x4"/>
+			<xs:enumeration value="2x6"/>
+			<xs:enumeration value="2x8"/>
+			<xs:enumeration value="2x10"/>
+			<xs:enumeration value="2x12"/>
+			<xs:enumeration value="2x14"/>
+			<xs:enumeration value="2x16"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StudMaterial">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="wood"/>
+			<xs:enumeration value="metal"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoorMaterial">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="solid wood"/>
+			<xs:enumeration value="hollow wood"/>
+			<xs:enumeration value="uninsulated metal"/>
+			<xs:enumeration value="insulated metal"/>
+			<xs:enumeration value="glass"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoorType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="interior"/>
+			<xs:enumeration value="exterior"/>
+			<xs:enumeration value="storm"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RValue">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Insulation Below-->
+	<xs:simpleType name="DoorThirdPartyCertifications">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InstallationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cavity"/>
+			<xs:enumeration value="continuous"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InsulationBattType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="fiberglass"/>
+			<xs:enumeration value="rockwool"/>
+			<xs:enumeration value="recycled cotton"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InsulationLooseFillType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cellulose"/>
+			<xs:enumeration value="fiberglass"/>
+			<xs:enumeration value="rockwool"/>
+			<xs:enumeration value="vermiculite"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InsulationRigidType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="polyisocyanurate"/>
+			<xs:enumeration value="xps"/>
+			<xs:enumeration value="eps"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InsulationSprayFoamType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="open cell"/>
+			<xs:enumeration value="closed cell"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InsulationCondition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="good"/>
+			<xs:enumeration value="fair"/>
+			<xs:enumeration value="poor"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Lighting Below-->
+	<!--Lighting Controls Below-->
+	<xs:simpleType name="InsulationLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="interior"/>
+			<xs:enumeration value="exterior"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LightingLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="interior"/>
+			<xs:enumeration value="exterior"/>
+			<xs:enumeration value="common area"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FluorescentTubeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="T2"/>
+			<xs:enumeration value="T4"/>
+			<xs:enumeration value="T5"/>
+			<xs:enumeration value="T8"/>
+			<xs:enumeration value="super T8"/>
+			<xs:enumeration value="T9"/>
+			<xs:enumeration value="T10"/>
+			<xs:enumeration value="T12"/>
+			<xs:enumeration value="T17"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FluorescentBallastType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="electronic"/>
+			<xs:enumeration value="magnetic"/>
+			<xs:enumeration value="instant start"/>
+			<xs:enumeration value="rapid start"/>
+			<xs:enumeration value="programmed start"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LightingThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LightingDailyHours">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1 to 4 hours per day"/>
+			<xs:enumeration value="4 to 12 hours per day"/>
+			<xs:enumeration value="more than 12 hours per day"/>
+			<xs:enumeration value="all day"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LightingControls">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="daylight dimming"/>
+			<xs:enumeration value="occupancy sensors"/>
+			<xs:enumeration value="vacancy sensors"/>
+			<xs:enumeration value="manual dimming"/>
+			<xs:enumeration value="bi-level control"/>
+			<xs:enumeration value="timers"/>
+			<xs:enumeration value="manual"/>
+			<xs:enumeration value="advanced controls"/>
+			<xs:enumeration value="part of emcs"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Moisture Control Below-->
+	<xs:simpleType name="ExteriorLocationsWaterIntrusionorDamage">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="roof"/>
+			<xs:enumeration value="interior ceiling"/>
+			<xs:enumeration value="foundation"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="crawlspace"/>
+			<xs:enumeration value="walls"/>
+			<xs:enumeration value="around windows"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InteriorLocationsofWaterLeaksorDamage">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="kitchen "/>
+			<xs:enumeration value="bathroom"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Plug Load Controls Below-->
+	<!--Shading and Solar Reflectance Below-->
+	<xs:simpleType name="PlugLoadControlType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="advanced power strip for AV"/>
+			<xs:enumeration value="advanced power strip for IT"/>
+			<xs:enumeration value="whole-house energy management system"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RadiantBarrierLocation">
+		<xs:annotation>
+			<xs:documentation>Enumerations from http://www.fsec.ucf.edu/en/publications/pdf/FSEC-DN-7-84.pdf</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="top side of truss under sheathing"/>
+			<xs:enumeration value="below bottom chord of truss"/>
+			<xs:enumeration value="attic floor"/>
+			<xs:enumeration value="underside of rafters"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Ventilation Below-->
+	<!--Window Group Below-->
+	<xs:simpleType name="HVACThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="Energy Star Most Efficient"/>
+			<xs:enumeration value="CEE Tier 1"/>
+			<xs:enumeration value="CEE Tier 2"/>
+			<xs:enumeration value="CEE Tier 3"/>
+			<xs:enumeration value="NEEP Cold-Climate Air-Source Heat Pump Specification"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DHWThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="CEE Tier 1"/>
+			<xs:enumeration value="CEE Tier 2"/>
+			<xs:enumeration value="CEE Tier 3"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GlassLayers">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="single-pane"/>
+			<xs:enumeration value="double-pane"/>
+			<xs:enumeration value="triple-pane"/>
+			<xs:enumeration value="multi-layered"/>
+			<xs:enumeration value="single-paned with storms"/>
+			<xs:enumeration value="single-paned with low-e storms"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WindowThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SHGC">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxExclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InteriorShading">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="light blinds"/>
+			<xs:enumeration value="dark blinds"/>
+			<xs:enumeration value="light shades"/>
+			<xs:enumeration value="dark shades"/>
+			<xs:enumeration value="light curtains"/>
+			<xs:enumeration value="dark curtains"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExteriorShading">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="external overhangs"/>
+			<xs:enumeration value="awnings"/>
+			<xs:enumeration value="solar screens"/>
+			<xs:enumeration value="solar film"/>
+			<xs:enumeration value="deciduous tree"/>
+			<xs:enumeration value="evergreen tree"/>
+			<xs:enumeration value="building"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Treatments">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="window film"/>
+			<xs:enumeration value="solar screen"/>
+			<xs:enumeration value="shading"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UFactor">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Combustion Applicance Tests Below-->
+	<xs:simpleType name="FlueCondition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="pass"/>
+			<xs:enumeration value="fail"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Combustion Appliance Zone Test Below-->
+	<xs:simpleType name="CAZDepressurizationLimit">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<xs:simpleType name="OpenClosed">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="open"/>
+			<xs:enumeration value="closed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DepressurizationFindingPoorCase">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="pass"/>
+			<xs:enumeration value="fail"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NetPressureChange">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<!--Cooling System Information Below-->
+	<xs:simpleType name="CoolingSystemType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="central air conditioning"/>
+			<xs:enumeration value="mini-split"/>
+			<xs:enumeration value="room air conditioner"/>
+			<xs:enumeration value="evaporative cooler"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CoolingEfficiencyUnits">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SEER"/>
+			<xs:enumeration value="EER"/>
+			<xs:enumeration value="COP"/>
+			<xs:enumeration value="kW/ton"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HeatingEfficiencyUnits">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="HSPF"/>
+			<xs:enumeration value="COP"/>
+			<xs:enumeration value="AFUE"/>
+			<xs:enumeration value="Percent"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DistrictSteamType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1-pipe"/>
+			<xs:enumeration value="2-pipe"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Efficiency">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Heat Pump Information Below-->
+	<xs:simpleType name="GeothermalLoop">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="open"/>
+			<xs:enumeration value="closed"/>
+			<xs:enumeration value="direct expansion"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HeatPumpType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="water-to-air"/>
+			<xs:enumeration value="water-to-water"/>
+			<xs:enumeration value="air-to-air"/>
+			<xs:enumeration value="mini-split"/>
+			<xs:enumeration value="ground-to-air"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VentSystem">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="atmospheric"/>
+			<xs:enumeration value="induced draft"/>
+			<xs:enumeration value="power vented (at unit)"/>
+			<xs:enumeration value="power vented (at exterior)"/>
+			<xs:enumeration value="direct vented"/>
+			<xs:enumeration value="sealed combustion"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Heating System Information Below-->
+	<xs:simpleType name="AFUE">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="COP">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--HVAC Distribution Below-->
+	<xs:simpleType name="HSPF">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SEER">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EER">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="kWperTon">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuctType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="supply"/>
+			<xs:enumeration value="return"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuctMaterial">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="duct board"/>
+			<xs:enumeration value="sheet metal"/>
+			<xs:enumeration value="galvanized"/>
+			<xs:enumeration value="flexible"/>
+			<xs:enumeration value="fiberboard"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuctLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="conditioned space"/>
+			<xs:enumeration value="unconditioned space"/>
+			<xs:enumeration value="unconditioned basement"/>
+			<xs:enumeration value="unvented crawlspace"/>
+			<xs:enumeration value="vented crawlspace"/>
+			<xs:enumeration value="crawlspace"/>
+			<xs:enumeration value="unconditioned attic"/>
+			<xs:enumeration value="interstitial space"/>
+			<xs:enumeration value="garage"/>
+			<xs:enumeration value="outside"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuctLeakageTestMethod">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="duct leakage tester"/>
+			<xs:enumeration value="blower door subtract"/>
+			<xs:enumeration value="pressure pan"/>
+			<xs:enumeration value="visual inspection"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuctLeakageTestUnitofMeasure">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CFM50"/>
+			<xs:enumeration value="CFM25"/>
+			<xs:enumeration value="CFM per Std 152"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LeakinessObservedVisualInspection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="connections sealed w mastic"/>
+			<xs:enumeration value="no observable leaks"/>
+			<xs:enumeration value="some observable leaks"/>
+			<xs:enumeration value="significant leaks"/>
+			<xs:enumeration value="catastrophic leaks"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MeasuredDuctLeakage">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<!--HVAC System Below-->
+	<xs:simpleType name="AirHandlerStaticPressureMeasurementLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="in ducts"/>
+			<xs:enumeration value="at equipment"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StaticPressureSource">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="as measured"/>
+			<xs:enumeration value="per design report"/>
+			<xs:enumeration value="per OEM documentation"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Capacity">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<xs:simpleType name="HVACMaintenanceSchedule">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="none"/>
+			<xs:enumeration value="yes - unspecified"/>
+			<xs:enumeration value="as needed"/>
+			<xs:enumeration value="daily"/>
+			<xs:enumeration value="weekly"/>
+			<xs:enumeration value="bi-weekly"/>
+			<xs:enumeration value="monthly"/>
+			<xs:enumeration value="semi-quarterly"/>
+			<xs:enumeration value="quarterly"/>
+			<xs:enumeration value="semi-annually"/>
+			<xs:enumeration value="annually"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DispositionofExistingSystem">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="Manufacturer">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="Model">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="UnitLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="attic - conditioned"/>
+			<xs:enumeration value="attic - unconditioned"/>
+			<xs:enumeration value="basement - conditioned"/>
+			<xs:enumeration value="basement - unconditioned"/>
+			<xs:enumeration value="conditioned space"/>
+			<xs:enumeration value="crawlspace - vented"/>
+			<xs:enumeration value="crawlspace - unvented"/>
+			<xs:enumeration value="garage - conditioned"/>
+			<xs:enumeration value="garage - unconditioned"/>
+			<xs:enumeration value="mechanical closet"/>
+			<xs:enumeration value="other interior"/>
+			<xs:enumeration value="other exterior"/>
+			<xs:enumeration value="roof deck"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Thermostats Below-->
+	<xs:simpleType name="Temperature">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<xs:simpleType name="ThermostatType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="programmable thermostat"/>
+			<xs:enumeration value="manual thermostat"/>
+			<xs:enumeration value="digital thermostat"/>
+			<xs:enumeration value="timer"/>
+			<xs:enumeration value="EMCS"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HotWaterResetControl">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="seasonal"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Hours">
+		<xs:restriction base="xs:integer"/>
+	</xs:simpleType>
+	<!--Water Heating System Below-->
+	<xs:simpleType name="EnergyFactor">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxInclusive value="5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PipeInsulated">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="RecoveryEfficiency">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxInclusive value="5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Volume">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ThermalEfficiency">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ProjectType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<!--Appliances Below-->
+	<!--Clothes Dryers Below-->
+	<!--Clothes Washer Below-->
+	<xs:simpleType name="ApplianceThirdPartyCertifications">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="Energy Star Most Efficient"/>
+			<xs:enumeration value="CEE Tier 1"/>
+			<xs:enumeration value="CEE Tier 2"/>
+			<xs:enumeration value="CEE Tier 3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Dishwasher Below-->
+	<xs:simpleType name="DishwasherType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="uncategorized"/>
+			<xs:enumeration value="built-in under counter"/>
+			<xs:enumeration value="portable"/>
+			<xs:enumeration value="counter-top"/>
+			<xs:enumeration value="single tank"/>
+			<xs:enumeration value="conveyor"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RatedAnnualkWh">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RatedWaterGalPerCycle">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Freezer Below-->
+	<!--Refrigerators Below-->
+	<!--Energy Savings Information Below-->
+	<xs:simpleType name="TotalCostHealthSafetyMeasures">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<xs:simpleType name="TotalCostQualEnergyMeasures">
+		<xs:restriction base="xs:double"/>
+	</xs:simpleType>
+	<!--Homeowner Questionaire Below-->
+	<xs:simpleType name="HomeownerQuestionaireScore">
+		<xs:annotation>
+			<xs:documentation>1-10 score of why they chose that option</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--Software Information Below-->
+	<xs:simpleType name="SoftwareProgramUsed">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="SoftwareProgramVersion">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<!--Contractor / Contracting Company Information Below-->
+	<xs:simpleType name="BusinessSpecialization">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="energy audit"/>
+			<xs:enumeration value="hvac"/>
+			<xs:enumeration value="insulation"/>
+			<xs:enumeration value="carpentry"/>
+			<xs:enumeration value="plumbing"/>
+			<xs:enumeration value="electrical"/>
+			<xs:enumeration value="painting"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BusinessType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="contractor"/>
+			<xs:enumeration value="auditor"/>
+			<xs:enumeration value="subcontractor"/>
+			<xs:enumeration value="property manager"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AuditorQualification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="CEM"/>
+			<xs:enumeration value="BPI-BA"/>
+			<xs:enumeration value="RESNET-Home Partner"/>
+			<xs:enumeration value="RA"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ImplementerQualification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="CEM"/>
+			<xs:enumeration value="BPI-BA"/>
+			<xs:enumeration value="BPI-MFBA"/>
+			<xs:enumeration value="RESNET-Home Partner"/>
+			<xs:enumeration value="RA"/>
+			<xs:enumeration value="Refrigerating System Operating Engineer"/>
+			<xs:enumeration value="High Pressure Boiler Operating Engineer"/>
+			<xs:enumeration value="HEP - EA"/>
+			<xs:enumeration value="HEP - QCI"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AzimuthType">
+		<xs:annotation>
+			<xs:documentation>Gives compass direction a surface (window, wall) is facing. Measured in degrees clockwise from North.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="0"/>
+			<xs:maxExclusive value="360"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="energyUnitType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cmh"/>
+			<xs:enumeration value="ccf"/>
+			<xs:enumeration value="kcf"/>
+			<xs:enumeration value="Mcf"/>
+			<xs:enumeration value="cfh"/>
+			<xs:enumeration value="kWh"/>
+			<xs:enumeration value="MWh"/>
+			<xs:enumeration value="Btu"/>
+			<xs:enumeration value="kBtu"/>
+			<xs:enumeration value="MBtu"/>
+			<xs:enumeration value="therms"/>
+			<xs:enumeration value="lbs"/>
+			<xs:enumeration value="kLbs"/>
+			<xs:enumeration value="MLbs"/>
+			<xs:enumeration value="tonnes"/>
+			<xs:enumeration value="cords"/>
+			<xs:enumeration value="gal"/>
+			<xs:enumeration value="kgal"/>
+			<xs:enumeration value="ton hours"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="waterUnitType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gal"/>
+			<xs:enumeration value="kgal"/>
+			<xs:enumeration value="Mgal"/>
+			<xs:enumeration value="cf"/>
+			<xs:enumeration value="ccf"/>
+			<xs:enumeration value="kcf"/>
+			<xs:enumeration value="Mcf"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MeterReadingType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="point"/>
+			<xs:enumeration value="median"/>
+			<xs:enumeration value="average"/>
+			<xs:enumeration value="total"/>
+			<xs:enumeration value="estimate"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WaterType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="indoor and outdoor water"/>
+			<xs:enumeration value="indoor water "/><!-- deprecated -->
+			<xs:enumeration value="indoor water"/>
+			<xs:enumeration value="outdoor water"/>
+			<xs:enumeration value="wastewater/sewer"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WaterUseIntensityUnits">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gal/sq.ft."/>
+			<xs:enumeration value="gal/day/person"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="endUseType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Heating"/>
+			<xs:enumeration value="Cooling"/>
+			<xs:enumeration value="HotWater"/>
+			<xs:enumeration value="Appliance"/>
+			<xs:enumeration value="Lighting"/>
+			<xs:enumeration value="PV"/>
+			<xs:enumeration value="SolarThermal"/>
+			<xs:enumeration value="Other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MeasuredOrEstimated">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="estimated"/>
+			<xs:enumeration value="measured"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GrossOrNet">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gross"/>
+			<xs:enumeration value="net"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SurfaceArea">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TransactionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="create"/>
+			<xs:enumeration value="update"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AuditorRelationship">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="HVACInstallationStandard">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ACCA 5 QI HVAC"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HVACSizingCalcs">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="manual j"/>
+			<xs:enumeration value="manual j and manual d"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HydronicDistributionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="radiator"/>
+			<xs:enumeration value="baseboard"/>
+			<xs:enumeration value="radiant floor"/>
+			<xs:enumeration value="radiant ceiling"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AirDistributionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="regular velocity"/>
+			<xs:enumeration value="high velocity"/>
+			<xs:enumeration value="gravity"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ElectricDistributionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="baseboard"/>
+			<xs:enumeration value="radiant floor"/>
+			<xs:enumeration value="radiant ceiling"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AirHandlerMotorType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="PSC single-speed"/>
+			<xs:enumeration value="PSC multi-speed"/>
+			<xs:enumeration value="ECM"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PlugLoadType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="TV plasma"/>
+			<xs:enumeration value="TV CRT"/>
+			<xs:enumeration value="TV other"/>
+			<xs:enumeration value="computer"/>
+			<xs:enumeration value="space heater"/>
+			<xs:enumeration value="water bed"/>
+			<xs:enumeration value="aquarium"/>
+			<xs:enumeration value="electric vehicle charging"/>
+			<xs:enumeration value="well pump"/>
+			<xs:enumeration value="sauna"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PlugLoadLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="interior"/>
+			<xs:enumeration value="exterior"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PlugLoadUnits">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="kWh/year"/>
+			<xs:enumeration value="W"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WindowCondition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="good"/>
+			<xs:enumeration value="moderate"/>
+			<xs:enumeration value="poor"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GasFill">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="air"/>
+			<xs:enumeration value="argon"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GlassType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="low-e"/>
+			<xs:enumeration value="tinted"/>
+			<xs:enumeration value="reflective"/>
+			<xs:enumeration value="tinted/reflective"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClothesWasherType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="top loader"/>
+			<xs:enumeration value="front loader"/>
+			<xs:enumeration value="all-in-one combination washer/dryer"/>
+			<xs:enumeration value="unitized/stacked washer-dryer pair"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClothesDryerType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="dryer"/>
+			<xs:enumeration value="all-in-one combination washer/dryer"/>
+			<xs:enumeration value="unitized/stacked washer-dryer pair"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LaundryMachineLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="laundry room"/>
+			<xs:enumeration value="living space"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FreezerStyle">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="uncategorized"/>
+			<xs:enumeration value="manual defrost"/>
+			<xs:enumeration value="frost free"/>
+			<xs:enumeration value="walk-in"/>
+			<xs:enumeration value="case"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RefrigeratorStyle">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="side-by-side"/>
+			<xs:enumeration value="top freezer"/>
+			<xs:enumeration value="bottom freezer"/>
+			<xs:enumeration value="single door"/>
+			<xs:enumeration value="full-size one door"/>
+			<xs:enumeration value="full-size two doors"/>
+			<xs:enumeration value="half or quarter size"/>
+			<xs:enumeration value="walk-in"/>
+			<xs:enumeration value="open case"/>
+			<xs:enumeration value="closed case"/>
+			<xs:enumeration value="uncategorized"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RefrigeratorLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="kitchen"/>
+			<xs:enumeration value="living space"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="garage"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DehumidifierLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="living space"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WaterHeaterType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="storage water heater"/>
+			<xs:enumeration value="dedicated boiler with storage tank"/>
+			<xs:enumeration value="instantaneous water heater"/>
+			<xs:enumeration value="heat pump water heater"/>
+			<xs:enumeration value="space-heating boiler with storage tank"/>
+			<xs:enumeration value="space-heating boiler with tankless coil"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SolarThermalSystemType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="hot water"/>
+			<xs:enumeration value="hot water and space heating"/>
+			<xs:enumeration value="space heating"/>
+			<xs:enumeration value="hybrid system"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SolarThermalCollectorLoopType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="air direct"/>
+			<xs:enumeration value="air indirect"/>
+			<xs:enumeration value="liquid direct"/>
+			<xs:enumeration value="liquid indirect"/>
+			<xs:enumeration value="passive thermosyphon"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SolarThermalCollectorType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="single glazing black"/>
+			<xs:enumeration value="single glazing selective"/>
+			<xs:enumeration value="double glazing black"/>
+			<xs:enumeration value="double glazing selective"/>
+			<xs:enumeration value="evacuated tube"/>
+			<xs:enumeration value="integrated collector storage"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ResourceTypeCode">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="Quantity">
+		<xs:restriction base="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="ProgramName">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="Title">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="StartDate">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="CompleteDateEstimated">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="CompleteDateActual">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="Notes">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="MeasureCode">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="MeasureDescription">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="EstimatedLife">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="InstallationDate">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="Cost">
+		<xs:restriction base="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="FundingSourceCode">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="TotalAmount">
+		<xs:restriction base="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="FundingSourceName">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="IncentiveAmount">
+		<xs:restriction base="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="LoadProfile">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="AnnualAmount">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="JobRole">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="Fraction">
+		<xs:annotation>
+			<xs:documentation>A fraction that has to be between 0 and 1 inclusive</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FractionGreaterThanOne">
+		<xs:annotation>
+			<xs:documentation>A fraction that can be greater than one (ie 110%)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AtticType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cape cod"/>
+			<xs:enumeration value="cathedral ceiling"/>
+			<xs:enumeration value="flat roof"/>
+			<xs:enumeration value="unvented attic"/>
+			<xs:enumeration value="vented attic"/>
+			<xs:enumeration value="venting unknown attic"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ImprovementStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Installed"/>
+			<xs:enumeration value="NotInstalled"/>
+			<xs:enumeration value="Recommended"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TestResultType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="passed"/>
+			<xs:enumeration value="failed"/>
+			<xs:enumeration value="not tested"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FoundationThermalBoundary">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="frame floor"/>
+			<xs:enumeration value="foundation wall"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WallAndRoofColor">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="light"/>
+			<xs:enumeration value="medium"/>
+			<xs:enumeration value="medium dark"/>
+			<xs:enumeration value="dark"/>
+			<xs:enumeration value="reflective"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RoofType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="shingles"/>
+			<xs:enumeration value="slate or tile shingles"/>
+			<xs:enumeration value="wood shingles or shakes"/>
+			<xs:enumeration value="asphalt or fiberglass shingles"/>
+			<xs:enumeration value="metal surfacing"/>
+			<xs:enumeration value="expanded polystyrene sheathing"/>
+			<xs:enumeration value="plastic/rubber/synthetic sheeting"/>
+			<xs:enumeration value="concrete"/>
+			<xs:enumeration value="cool roof"/>
+			<xs:enumeration value="green roof"/>
+			<xs:enumeration value="no one major type"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DeckType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="concrete"/>
+			<xs:enumeration value="metal"/>
+			<xs:enumeration value="wood"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Siding">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="wood siding"/>
+			<xs:enumeration value="stucco"/>
+			<xs:enumeration value="synthetic stucco"/>
+			<xs:enumeration value="vinyl siding"/>
+			<xs:enumeration value="aluminum siding"/>
+			<xs:enumeration value="brick veneer"/>
+			<xs:enumeration value="asbestos siding"/>
+			<xs:enumeration value="fiber cement siding"/>
+			<xs:enumeration value="composite shingle siding"/>
+			<xs:enumeration value="masonite siding"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LengthMeasurement">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InsulationGrade">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FloorCovering">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="carpet"/>
+			<xs:enumeration value="tile"/>
+			<xs:enumeration value="hardwood"/>
+			<xs:enumeration value="vinyl"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Pitch">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Tilt">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="90"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PVSystemLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="roof"/>
+			<xs:enumeration value="ground"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PVSystemOwnership">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="leased"/>
+			<xs:enumeration value="owned"/>
+			<xs:enumeration value="power purchase agreement"/>
+			<xs:enumeration value="utility owned"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Power">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ZoneType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="conditioned"/>
+			<xs:enumeration value="unconditioned"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WholeBldgVentilationRequirementMethod">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ASHRAE 62.2-1989"/>
+			<xs:enumeration value="ASHRAE 62.2-2007"/>
+			<xs:enumeration value="ASHRAE 62.2-2010"/>
+			<xs:enumeration value="ASHRAE 62.2-2013"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BooleanWithNA">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="true"/>
+			<xs:enumeration value="false"/>
+			<xs:enumeration value="na"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VentilationRateUnits">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ACH"/>
+			<xs:enumeration value="CFMnat"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VentilationFanThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="Home Ventilation Institute"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Recommendation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="require"/>
+			<xs:enumeration value="recommend"/>
+			<xs:enumeration value="no recommendation"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpotVentilationLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="kitchen"/>
+			<xs:enumeration value="bath"/>
+			<xs:enumeration value="garage"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpotVentilationUnits">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CFM"/>
+			<xs:enumeration value="ACH"/>
+			<xs:enumeration value="L/s"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VentilationFanType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="exhaust only"/>
+			<xs:enumeration value="supply only"/>
+			<xs:enumeration value="heat recovery ventilator"/>
+			<xs:enumeration value="energy recovery ventilator"/>
+			<xs:enumeration value="balanced"/>
+			<xs:enumeration value="central fan integrated supply"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HoursPerDay">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="24"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VentilationFanLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="bath"/>
+			<xs:enumeration value="kitchen"/>
+			<xs:enumeration value="hallway"/>
+			<xs:enumeration value="garage"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="eGridRegions">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Alaska"/>
+			<xs:enumeration value="Eastern"/>
+			<xs:enumeration value="ERCOT"/>
+			<xs:enumeration value="Hawaii"/>
+			<xs:enumeration value="Western"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ProgramSponsor">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="CertifyingOrganization">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="USGBC"/>
+			<xs:enumeration value="NAHB"/>
+			<xs:enumeration value="Energy Star Home"/>
+			<xs:enumeration value="local program"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ProgramCertificate">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Home Performance with Energy Star"/>
+			<xs:enumeration value="LEED Certified"/>
+			<xs:enumeration value="LEED Silver"/>
+			<xs:enumeration value="LEED Gold"/>
+			<xs:enumeration value="LEED Platinum"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BoilerType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="hot water"/>
+			<xs:enumeration value="steam"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+
+	<xs:simpleType name="KnownOrEstimated">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="known"/>
+			<xs:enumeration value="estimated"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PoolType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="in ground"/>
+			<xs:enumeration value="on ground"/>
+			<xs:enumeration value="above ground"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MonthsPerYear">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="12"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PoolFilterType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="sand"/>
+			<xs:enumeration value="diatomaceous earth"/>
+			<xs:enumeration value="cartridge"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PoolPumpType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="single speed"/>
+			<xs:enumeration value="multi speed"/>
+			<xs:enumeration value="variable speed"/>
+			<xs:enumeration value="variable flow"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PoolPump3rdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ENERGY STAR"/>
+			<xs:enumeration value="ENERGY STAR Most Efficient"/>
+			<xs:enumeration value="CEE Tier 1"/>
+			<xs:enumeration value="CEE Tier 2"/>
+			<xs:enumeration value="Cee Tier 3"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PoolPumpSpeedSetting">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="low"/>
+			<xs:enumeration value="high"/>
+			<xs:enumeration value="most efficient"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Speed">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FlowRate">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PoolCleanerType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="robotic"/>
+			<xs:enumeration value="suction side"/>
+			<xs:enumeration value="pressure side"/>
+			<xs:enumeration value="booster pump"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PoolHeaterType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gas fired"/>
+			<xs:enumeration value="electric resistance"/>
+			<xs:enumeration value="heat pump"/>
+			<xs:enumeration value="solar"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BPI2400CalibrationQualification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="none"/>
+			<xs:enumeration value="detailed"/>
+			<xs:enumeration value="simple"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WeatherStationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="TMY"/>
+			<xs:enumeration value="TMY2"/>
+			<xs:enumeration value="TMY3"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuctLeakageTotalOrToOutside">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="to outside"/>
+			<xs:enumeration value="total"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WeatherStationUse">
+		<xs:annotation>
+			<xs:documentation>By leaving this field empty, the weather station is assumed used for all functions such as utility bill regression analysis and energy model simulations. If different weather stations are used for the different functions, use this field to specify the usage of each weather station.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="billing analysis"/>
+			<xs:enumeration value="energy modeling"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WaterFixtureType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="faucet"/>
+			<xs:enumeration value="shower head"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WaterFixtureThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="Energy Star Most Efficient"/>
+			<xs:enumeration value="WaterSense"/>
+			<xs:enumeration value="CEE Tier 1"/>
+			<xs:enumeration value="CEE Tier 2"/>
+			<xs:enumeration value="CEE Tier 3"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LightingFixtureThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Energy Star"/>
+			<xs:enumeration value="Energy Star Most Efficient"/>
+			<xs:enumeration value="CEE Tier 1"/>
+			<xs:enumeration value="CEE Tier 2"/>
+			<xs:enumeration value="CEE Tier 3"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PeopleCount">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WindThirdPartyCertification">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AWEA 9.1-2009"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DrainWaterHeatRecoveryFacilitiesConnected">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="one"/>
+			<xs:enumeration value="all"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RecirculationControlType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="no control"/>
+			<xs:enumeration value="timer"/>
+			<xs:enumeration value="temperature"/>
+			<xs:enumeration value="presence sensor demand control"/>
+			<xs:enumeration value="manual demand control"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MERV">
+		<xs:restriction base="xs:int">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SolarAbsorptance">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Emittance">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
Updates the translator to use HPXML v2.3. Including the following translation changes:

 - Translating the new `FloorFurnace` element into a `wall_furnace` in HEScore.
 - Translating new "medium dark" `RoofColor`.
 - Utilizing the new `Roof/SolarAbsorptance` element in HPXML to pass that through to HPXML when present.