### PR TITLE
Add cond_attic translation

### DIFF
--- a/docs/source/translation/zone_roof.rst
+++ b/docs/source/translation/zone_roof.rst
@@ -30,16 +30,19 @@ type according to the following mapping.
    unvented attic         vented_attic
    vented attic           vented_attic
    venting unknown attic  vented_attic
-   other                  *not translated*
+   other                  *see note below*
    =====================  ================
 
-.. warning:: 
+.. note::
    
-   There is no way to get a HEScore ``cond_attic``.
+   Currently, there's no existing HPXML element capturing a conditioned attic.
+   The only way to model a HEScore ``cond_attic`` is to specify HPXML Attic Type
+   to be ``other`` with an extra element ``Attic/extension/Conditioned`` to be
+   ``true``.
 
-.. note::   
-   
-   Items that are *not translated* will result in a translation error.
+   Otherwise, HPXML Attic Type ``other`` will not be translated and will
+   result in a translation error.
+
    
 HEScore can accept up to two attic/roof constructions. If there are more than
 two specified in HPXML, the properties of the ``Attic`` elements with

--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -923,8 +923,8 @@ class HPXMLtoHEScoreTranslator(object):
             hpxml_attic_type = xpath(attic, 'h:AtticType/text()')
             atticd['rooftype'] = rooftypemap[hpxml_attic_type]
             if atticd['rooftype'] is None:
-                attc_is_cond = xpath(attic, 'boolean(h:extension/h:Conditioned)')
-                if attc_is_cond:
+                attc_is_cond = xpath(attic, 'h:extension/h:Conditioned/text()')
+                if attc_is_cond == 'true':
                     atticd['rooftype'] = 'cond_attic'
                 else:
                     raise TranslationError(

--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -923,9 +923,13 @@ class HPXMLtoHEScoreTranslator(object):
             hpxml_attic_type = xpath(attic, 'h:AtticType/text()')
             atticd['rooftype'] = rooftypemap[hpxml_attic_type]
             if atticd['rooftype'] is None:
-                raise TranslationError(
-                    'Attic {}: Cannot translate HPXML AtticType {} to HEScore rooftype.'.format(atticid,
-                                                                                                hpxml_attic_type))
+                attc_is_cond = xpath(attic, 'boolean(h:extension/h:Conditioned)')
+                if attc_is_cond:
+                    atticd['rooftype'] = 'cond_attic'
+                else:
+                    raise TranslationError(
+                        'Attic {}: Cannot translate HPXML AtticType {} to HEScore rooftype.'.format(atticid,
+                                                                                                    hpxml_attic_type))
 
             # Roof color
             solar_absorptance = convert_to_type(float, xpath(roof, 'h:SolarAbsorptance/text()'))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1970,6 +1970,21 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         self.assertEqual(system['type'], 'tankless')
         self.assertAlmostEqual(system['energy_factor'], 0.7)
 
+    def test_conditioned_attic(self):
+        tr = self._load_xmlfile('house4')
+        attic = self.xpath('//h:Attic[h:SystemIdentifier/@id="attic1"]')
+        attic_type = self.xpath('//h:Attic[h:SystemIdentifier/@id="attic1"]/h:AtticType')
+        attic_type.text = 'other'
+        self.assertRaisesRegexp(
+            TranslationError,
+            r'Attic attic1: Cannot translate HPXML AtticType other to HEScore rooftype.',
+            tr.hpxml_to_hescore_dict
+        )
+        is_attic_cond = etree.SubElement(etree.SubElement(attic, tr.addns('h:extension')), tr.addns('h:Conditioned'))
+        is_attic_cond.text = 'true'
+        d = tr.hpxml_to_hescore_dict()
+        roof_type = d['building']['zone']['zone_roof'][0]['roof_type']
+        self.assertEqual(roof_type, 'cond_attic')
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1991,6 +1991,11 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
             r'Attic \w+: Cannot translate HPXML AtticType other to HEScore rooftype.',
             tr.hpxml_to_hescore_dict
         )
+        attic_type.text = 'vented attic'
+        is_attic_cond.text = 'true'
+        d = tr.hpxml_to_hescore_dict()
+        roof_type = d['building']['zone']['zone_roof'][0]['roof_type']
+        self.assertEqual(roof_type, 'vented_attic')
 
 
 if __name__ == "__main__":

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1986,5 +1986,6 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         roof_type = d['building']['zone']['zone_roof'][0]['roof_type']
         self.assertEqual(roof_type, 'cond_attic')
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allow HEScore conditioned attic to be translated from HPXML 2.3.
Fix #95 