### PR TITLE
Future py27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             pip install --user virtualenv
             python -m virtualenv env
             source env/bin/activate
-            pip install --progress-bar off .[dev]
+            pip install --progress-bar off .[test]
       - run:  &unittests
           name: Run Unittests
           command: |

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ setup(
     ],
     keywords='home energy score hescore doe nrel',
     packages=['hescorehpxml'],
-    install_requires=['lxml'],
+    install_requires=[
+        'lxml',
+        'future',
+    ],
     extras_require={
         'dev': [
             'flake8',
@@ -43,7 +46,6 @@ setup(
             'sphinx',
             'sphinx_rtd_theme',
             'sphinx-autobuild',
-            'future'
         ],
         'test': [
             'flake8',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='hescore-hpxml',
-    version='5.0.0',
+    version='5.0.1',
     description='HPXML Translator for the HEScore API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='hescore-hpxml',
-    version='5.0.1',
+    version='5.0.2',
     description='HPXML Translator for the HEScore API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,13 @@ setup(
             'sphinx_rtd_theme',
             'sphinx-autobuild',
             'future'
+        ],
+        'test': [
+            'flake8',
+            'coverage',
+            'sphinx',
+            'sphinx_rtd_theme',
+            'sphinx-autobuild',
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
Fixes #94 

This makes sure `future` is installed in the base installation as it should be. 