### PR TITLE
Fix for knee wall R-value causing div by zero

### DIFF
--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -1085,11 +1085,17 @@ class HPXMLtoHEScoreTranslator(object):
             # attic floor center of cavity R-value
             attic_floor_rvalue = xpath(attic, 'sum(h:AtticFloorInsulation/h:Layer/h:NominalRValue)')
             if knee_walls:
-                knee_wall_ua = sum(old_div(x['area'], x['rvalue']) for x in knee_walls)
+                try:
+                    knee_wall_ua = sum(x['area'] / x['rvalue'] for x in knee_walls)
+                except ZeroDivisionError:
+                    knee_wall_ua = float('inf')
                 knee_wall_area = sum([x['area'] for x in knee_walls])
-                attic_floor_adj_ua = knee_wall_ua + old_div(atticd['roof_area'], attic_floor_rvalue)
+                try:
+                    attic_floor_adj_ua = knee_wall_ua + atticd['roof_area'] / attic_floor_rvalue
+                except ZeroDivisionError:
+                    attic_floor_adj_ua = float('inf')
                 attic_floor_adj_area = knee_wall_area + atticd['roof_area']
-                attic_floor_rvalue = old_div(attic_floor_adj_area, attic_floor_adj_ua)
+                attic_floor_rvalue = attic_floor_adj_area / attic_floor_adj_ua
                 atticd['roof_area'] = attic_floor_adj_area
             atticd['attic_floor_coc_rvalue'] = \
                 min(attic_floor_rvalues, key=lambda x: abs(x - attic_floor_rvalue)) + 0.5

--- a/hescorehpxml/__main__.py
+++ b/hescorehpxml/__main__.py
@@ -1,0 +1,3 @@
+from . import main
+
+main()


### PR DESCRIPTION
In the calculation for adding knee wall area and R-value to to the attic floor, there was a divide by zero error on the UA calculation needed for that if the knee wall insulation R-value was zero or if the attic floor insulation R-value was zero. This fixes that. 