### PR TITLE
Succeeding at failure

### DIFF
--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -68,12 +68,13 @@ class ElementNotFoundError(TranslationError):
     @property
     def message(self):
         tree = self.parent.getroottree()
-        el_path = re.sub(r'{.*?}', '',tree.getelementpath(self.parent))
+        el_path = re.sub(r'{.*?}', '', tree.getelementpath(self.parent))
+        xpath = self.xpath.replace('h:', '')
         if self.kwargs:
             post = ' with args ' + str(self.kwargs)
         else:
             post = ''
-        return "Can't find element {}/{}{}".format(el_path, self.xpath, post)
+        return "Can't find element {}/{}{}".format(el_path, xpath, post)
 
     def __str__(self):
         return self.message

--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -2313,6 +2313,9 @@ def main():
         exmsg = ex.message
         logging.error('%s:%s', exclass, exmsg)
         sys.exit(1)
+    except Exception:
+        logging.error('Unknown HPXML Translation Error: Please contact HEScore support')
+        sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -637,7 +637,12 @@ class HPXMLtoHEScoreTranslator(object):
             hpxml_bldg_id = xpath(b, 'h:BuildingID/@id', raise_err=True)
 
         if hpxml_project_id is not None:
-            p = xpath(self.hpxmldoc, 'h:Project[h:ProjectID/@id=$projectid]', raise_err=True, projectid=hpxml_project_id)
+            p = xpath(
+                self.hpxmldoc,
+                'h:Project[h:ProjectID/@id=$projectid]',
+                raise_err=True,
+                projectid=hpxml_project_id
+            )
         else:
             p = xpath(self.hpxmldoc, 'h:Project[1]')
 
@@ -862,14 +867,14 @@ class HPXMLtoHEScoreTranslator(object):
                     float(xpath(bldg_cons_el, 'h:ConditionedFloorArea/text()', raise_err=True))
             except ElementNotFoundError:
                 raise TranslationError(
-                    'Either AverageCeilingHeight or both ConditionedBuildingVolume and ConditionedFloorArea are required.'
+                    'Either AverageCeilingHeight or both ConditionedBuildingVolume and ConditionedFloorArea are required.'  # noqa E501
                 )
         else:
             avg_ceiling_ht = float(avg_ceiling_ht)
         bldg_about['floor_to_ceiling_height'] = int(python2round(avg_ceiling_ht))
         bldg_about['conditioned_floor_area'] = int(python2round(float(xpath(
-            b, 
-            'h:BuildingDetails/h:BuildingSummary/h:BuildingConstruction/h:ConditionedFloorArea/text()', 
+            b,
+            'h:BuildingDetails/h:BuildingSummary/h:BuildingConstruction/h:ConditionedFloorArea/text()',
             raise_err=True
         ))))
 
@@ -1061,7 +1066,12 @@ class HPXMLtoHEScoreTranslator(object):
             # knee walls
             knee_walls = []
             for kneewall_idref in xpath(attic, 'h:AtticKneeWall/@idref', aslist=True):
-                wall = xpath(b, 'descendant::h:Wall[h:SystemIdentifier/@id=$kneewallid]', raise_err=True, kneewallid=kneewall_idref)
+                wall = xpath(
+                    b,
+                    'descendant::h:Wall[h:SystemIdentifier/@id=$kneewallid]',
+                    raise_err=True,
+                    kneewallid=kneewall_idref
+                )
                 wall_rvalue = xpath(wall, 'sum(h:Insulation/h:Layer/h:NominalRValue)')
                 wall_area = xpath(wall, 'h:Area/text()')
                 if wall_area is None:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='hescore-hpxml',
-    version='5.1.1',
+    version='5.2.0',
     description='HPXML Translator for the HEScore API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import datetime as dt
 from lxml import etree, objectify
-from hescorehpxml import HPXMLtoHEScoreTranslator, TranslationError, InputOutOfBounds
+from hescorehpxml import HPXMLtoHEScoreTranslator, TranslationError, InputOutOfBounds, ElementNotFoundError
 import io
 import json
 from copy import deepcopy
@@ -280,9 +280,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Roof[1]/h:RoofColor')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
-                                'Attic .+ Invalid or missing RoofColor',
-                                tr.hpxml_to_hescore_dict)
+        self.assertRaises(ElementNotFoundError,
+                          tr.hpxml_to_hescore_dict)
 
     def test_invalid_roof_type(self):
         tr = self._load_xmlfile('hescore_min')
@@ -325,9 +324,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Window[1]/h:Area')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
-                                r'All windows need an area\.',
-                                tr.hpxml_to_hescore_dict)
+        self.assertRaises(ElementNotFoundError,
+                          tr.hpxml_to_hescore_dict)
 
     def test_missing_window_orientation(self):
         tr = self._load_xmlfile('hescore_min')
@@ -542,10 +540,11 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
 
     def test_bldgid_not_found(self):
         tr = self._load_xmlfile('house1')
-        self.assertRaisesRegexp(TranslationError,
-                                r'HPXML BuildingID: "bldgnothere" not found',
-                                tr.hpxml_to_hescore_dict,
-                                hpxml_bldg_id='bldgnothere')
+        self.assertRaises(
+            ElementNotFoundError,
+            tr.hpxml_to_hescore_dict,
+            hpxml_bldg_id='bldgnothere'
+        )
 
     def test_missing_cooling_system(self):
         tr = self._load_xmlfile('hescore_min')
@@ -756,7 +755,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         self.xpath('//h:Wall[1]/h:Insulation/h:Layer[h:InstallationType="cavity"]/h:NominalRValue').text = '0'
         self.assertRaisesRegexp(
             TranslationError,
-            r'Envelope construction not supported',
+            r'Wall R-value outside HEScore bounds',
             tr.hpxml_to_hescore_dict
             )
 
@@ -810,11 +809,10 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         zipcode_el = self.xpath('//h:Building/h:Site/h:Address[h:AddressType="street"]/h:ZipCode')
         zipcode_el.getparent().remove(zipcode_el)
-        self.assertRaisesRegexp(
-            TranslationError,
-            r'ZipCode missing',
+        self.assertRaises(
+            ElementNotFoundError,
             tr.hpxml_to_hescore_dict
-            )
+        )
 
     def test_air_source_heat_pump_has_no_ducts(self):
         tr = self._load_xmlfile('house4')


### PR DESCRIPTION
This PR does a couple of things:

- Removes the "NREL Assumptions" code. We haven't used it in a long time and it's not relevant anymore.
- Catches more "element not found" errors and returns an error of which element is expected and missing.
- Finally, catches unexpected errors when run from the command line and gives a generic error message rather than a traceback.