### PR TITLE
Fixing CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,30 +22,6 @@ jobs:
           command: |
             source env/bin/activate
             python -m flake8
-      - run:
-          name: Run coverage tests
-          when: always
-          command: |
-            set +e
-            source env/bin/activate
-            python -m coverage run --source=hescorehpxml -m unittest discover -s tests > /dev/null 2>&1
-            python -m coverage report -m
-            python -m coverage html -d /tmp/coverage_report
-      - store_artifacts:
-          path: /tmp/coverage_report
-          destination: coverage-report
-      - run:
-          name: Build documentation
-          when: always
-          command: |
-            source env/bin/activate
-            cd docs
-            make html
-            mkdir /tmp/docs
-            cp -r build/html/* /tmp/docs
-      - store_artifacts:
-          path: /tmp/docs
-          destination: docs
   build-py36:
     docker:
       - image: circleci/python:3.6
@@ -70,6 +46,30 @@ jobs:
       - run: *install
       - run: *unittests
       - run: *stylechecks
+      - run:
+          name: Run coverage tests
+          when: always
+          command: |
+            set +e
+            source env/bin/activate
+            python -m coverage run --source=hescorehpxml -m unittest discover -s tests > /dev/null 2>&1
+            python -m coverage report -m
+            python -m coverage html -d /tmp/coverage_report
+      - store_artifacts:
+          path: /tmp/coverage_report
+          destination: coverage-report
+      - run:
+          name: Build documentation
+          when: always
+          command: |
+            source env/bin/activate
+            cd docs
+            make html
+            mkdir /tmp/docs
+            cp -r build/html/* /tmp/docs
+      - store_artifacts:
+          path: /tmp/docs
+          destination: docs
 
 workflows:
   version: 2

--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -18,11 +18,10 @@ def HPXMLtoHEScoreTranslator(hpxmlfilename):
         raise HPXMLtoHEScoreError('Schema version {} not supported.'.format('.'.join(schema_version)))
 
 
-def main():
+def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description='Convert HPXML v2.x or v3.x files to HEScore inputs')
     parser.add_argument(
         'hpxml_input',
-        type=argparse.FileType('r'),
         help='Filename of hpxml file'
     )
     parser.add_argument(
@@ -44,7 +43,7 @@ def main():
         help='HPXML contractor id to use in translating HPwES data if there are more than one <Contractor/> elements. Default: first one.' # noqa 501
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     logging.basicConfig(level=logging.ERROR, format='%(levelname)s:%(message)s')
     try:
         t = HPXMLtoHEScoreTranslator(args.hpxml_input)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='hescore-hpxml',
-    version='6.0',
+    version='6.0.1',
     description='HPXML Translator for the HEScore API',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,13 +6,14 @@ import os
 import unittest
 import datetime as dt
 from lxml import etree, objectify
-from hescorehpxml import HPXMLtoHEScoreTranslator
+from hescorehpxml import HPXMLtoHEScoreTranslator, main
 from hescorehpxml.exceptions import TranslationError, InputOutOfBounds, ElementNotFoundError
 import io
 import json
 from copy import deepcopy
 import uuid
 import sys
+import tempfile
 standard_library.install_aliases()  # noqa: 402
 
 
@@ -102,6 +103,20 @@ class TestAPIHouses(unittest.TestCase, ComparatorBase):
 
     def test_house8(self):
         self._do_full_compare('house8')
+
+
+class TestCLI(unittest.TestCase, ComparatorBase):
+
+    def test_cli_pass(self):
+        xml_file_path = os.path.abspath(os.path.join(thisdir, '..', 'examples', 'hescore_min.xml'))
+        tmpdir = tempfile.mkdtemp()
+        outfile = os.path.join(tmpdir, 'hescore_min.json')
+        main([xml_file_path, '-o', outfile])
+        with open(outfile, 'r') as f:
+            d1 = json.load(f)
+        with open(xml_file_path.replace('.xml', '.json'), 'r') as f:
+            d2 = json.load(f)
+        self._compare_item(d1, d2)
 
 
 class TestOtherHouses(unittest.TestCase, ComparatorBase):


### PR DESCRIPTION
For some reason, either in python3 or a newer version of lxml, the way we were reading in files from the command line no longer was able to be parsed by lxml. This was not caught by the tests because there were no tests on the CLI. This fixes the original problem _and_ adds a test for the CLI so we'll know if it regresses again.

cc @adamsten