### PR TITLE
Add export of HPXML file scrubbed of PII

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
           name: Run Unittests
           command: |
             source env/bin/activate
-            pytest
+            pytest --junitxml=/tmp/test_results
+      - store_test_results:
+          path: /tmp/test_results
       - run:  &stylechecks
           name: Run Style Checks
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: Run Unittests
           command: |
             source env/bin/activate
-            pytest --junitxml=/tmp/test_results
+            pytest --junitxml=/tmp/test_results/hescore-hpxml/results.xml
       - store_test_results:
           path: /tmp/test_results
       - run:  &stylechecks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: Run Unittests
           command: |
             source env/bin/activate
-            python -m unittest discover -s tests
+            pytest
       - run:  &stylechecks
           name: Run Style Checks
           command: |
@@ -52,7 +52,7 @@ jobs:
           command: |
             set +e
             source env/bin/activate
-            python -m coverage run --source=hescorehpxml -m unittest discover -s tests > /dev/null 2>&1
+            python -m coverage run --source=hescorehpxml -m pytest > /dev/null 2>&1
             python -m coverage report -m
             python -m coverage html -d /tmp/coverage_report
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  build-py27:
+  build-py36:
     docker:
-      - image: circleci/python:2
+      - image: circleci/python:3.6
     steps:
       - checkout
       - run:  &install
@@ -22,14 +22,6 @@ jobs:
           command: |
             source env/bin/activate
             python -m flake8
-  build-py36:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run: *install
-      - run: *unittests
-      - run: *stylechecks
   build-py37:
     docker:
       - image: circleci/python:3.7
@@ -75,7 +67,6 @@ workflows:
   version: 2
   test_all_py_versions:
     jobs:
-      - build-py27
       - build-py36
       - build-py37
       - build-py38

--- a/hescorehpxml/__init__.py
+++ b/hescorehpxml/__init__.py
@@ -42,6 +42,11 @@ def main(argv=sys.argv[1:]):
         '--contractorid',
         help='HPXML contractor id to use in translating HPwES data if there are more than one <Contractor/> elements. Default: first one.' # noqa 501
     )
+    parser.add_argument(
+        '--scrubbed-hpxml',
+        type=argparse.FileType('wb'),
+        help='Path to save HPXML file scrubbed of PII.'
+    )
 
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.ERROR, format='%(levelname)s:%(message)s')
@@ -60,6 +65,9 @@ def main(argv=sys.argv[1:]):
     except Exception:
         logging.error('Unknown HPXML Translation Error: Please contact HEScore support')
         sys.exit(2)
+    else:
+        if args.scrubbed_hpxml:
+            t.export_scrubbed_hpxml(args.scrubbed_hpxml)
 
 
 if __name__ == '__main__':

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -6,7 +6,7 @@ from past.utils import old_div
 import datetime as dt
 import json
 import math
-from lxml import etree
+from lxml import etree, objectify
 from collections import defaultdict, namedtuple
 from decimal import Decimal
 from collections import OrderedDict
@@ -103,6 +103,37 @@ class HPXMLtoHEScoreTranslatorBase(object):
                 return res
         else:
             return res
+
+    def export_scrubbed_hpxml(self, outfile_obj):
+        """Export an hpxml file scrubbed of potential PII
+
+        :param outfile_obj: writable filename or file-like object to write the scrubbed xml
+        :type outfile_obj: file-like object
+        """
+
+        # Make a copy of the original hpxml doc as an objectify tree
+        root = objectify.fromstring(etree.tostring(self.hpxmldoc))
+        E = objectify.ElementMaker(
+            annotate=False,
+            namespace=self.ns['h']
+        )
+
+        # Clean out the Customer elements
+        for customer in root.Customer:
+            customer_id = customer.CustomerDetails.Person.SystemIdentifier.attrib['id']
+            root.replace(
+                customer,
+                E.Customer(
+                    E.CustomerDetails(
+                        E.Person(
+                            E.SystemIdentifier(id=customer_id)
+                        )
+                    )
+                )
+            )
+
+        # Write out the scrubbed doc
+        etree.ElementTree(root).write(outfile_obj, pretty_print=True)
 
     def get_wall_assembly_code(self, hpxmlwall):
         xpath = self.xpath

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -119,19 +119,18 @@ class HPXMLtoHEScoreTranslatorBase(object):
         )
 
         # Clean out the Customer elements
-        if hasattr(root, 'Customer'):
-            for customer in root.Customer:
-                customer_id = customer.CustomerDetails.Person.SystemIdentifier.attrib['id']
-                root.replace(
-                    customer,
-                    E.Customer(
-                        E.CustomerDetails(
-                            E.Person(
-                                E.SystemIdentifier(id=customer_id)
-                            )
+        for customer in root.xpath('//h:Customer', namespaces=self.ns):
+            customer_id = customer.CustomerDetails.Person.SystemIdentifier.attrib['id']
+            root.replace(
+                customer,
+                E.Customer(
+                    E.CustomerDetails(
+                        E.Person(
+                            E.SystemIdentifier(id=customer_id)
                         )
                     )
                 )
+            )
 
         for el in root.xpath('//h:HealthAndSafety', namespaces=self.ns):
             el.getparent().remove(el)

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -119,18 +119,22 @@ class HPXMLtoHEScoreTranslatorBase(object):
         )
 
         # Clean out the Customer elements
-        for customer in root.Customer:
-            customer_id = customer.CustomerDetails.Person.SystemIdentifier.attrib['id']
-            root.replace(
-                customer,
-                E.Customer(
-                    E.CustomerDetails(
-                        E.Person(
-                            E.SystemIdentifier(id=customer_id)
+        if hasattr(root, 'Customer'):
+            for customer in root.Customer:
+                customer_id = customer.CustomerDetails.Person.SystemIdentifier.attrib['id']
+                root.replace(
+                    customer,
+                    E.Customer(
+                        E.CustomerDetails(
+                            E.Person(
+                                E.SystemIdentifier(id=customer_id)
+                            )
                         )
                     )
                 )
-            )
+
+        for el in root.xpath('//h:HealthAndSafety', namespaces=self.ns):
+            el.getparent().remove(el)
 
         # Write out the scrubbed doc
         etree.ElementTree(root).write(outfile_obj, pretty_print=True)

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -119,7 +119,7 @@ class HPXMLtoHEScoreTranslatorBase(object):
         )
 
         # Clean out the Customer elements
-        for customer in root.xpath('//h:Customer', namespaces=self.ns):
+        for customer in root.xpath('h:Customer', namespaces=self.ns):
             customer_id = customer.CustomerDetails.Person.SystemIdentifier.attrib['id']
             root.replace(
                 customer,
@@ -132,8 +132,17 @@ class HPXMLtoHEScoreTranslatorBase(object):
                 )
             )
 
-        for el in root.xpath('//h:HealthAndSafety', namespaces=self.ns):
-            el.getparent().remove(el)
+        elements_to_remove = [
+            '//h:HealthAndSafety',
+            '//h:BuildingOccupancy',
+            '//h:AnnualEnergyUse',
+            'h:Utility',
+            'h:Consumption',
+            'h:Building/h:CustomerID'
+        ]
+        for el_name in elements_to_remove:
+            for el in root.xpath(el_name, namespaces=self.ns):
+                el.getparent().remove(el)
 
         # Write out the scrubbed doc
         etree.ElementTree(root).write(outfile_obj, pretty_print=True)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
             'sphinx',
             'sphinx_rtd_theme',
             'sphinx-autobuild',
+            'pytest'
         ],
         'test': [
             'flake8',
@@ -53,6 +54,7 @@ setup(
             'sphinx',
             'sphinx_rtd_theme',
             'sphinx-autobuild',
+            'pytest'
         ]
     },
     include_package_data=True,

--- a/tests/test_scrub.py
+++ b/tests/test_scrub.py
@@ -84,7 +84,6 @@ def test_remove_health_and_safety(hpxml_filebase):
     )
     doc2 = scrub_hpxml_doc(doc)
     assert len(doc2.xpath('//h:HealthAndSafety', namespaces={'h': hpxml.nsmap[None]})) == 0
-    assert False
 
 
 @pytest.mark.parametrize('hpxml_filebase', both_hescore_min)

--- a/tests/test_scrub.py
+++ b/tests/test_scrub.py
@@ -1,0 +1,71 @@
+import io
+from lxml import etree, objectify
+import pathlib
+import re
+
+from hescorehpxml import HPXMLtoHEScoreTranslator
+
+
+def get_example_xml_tree_elementmaker(filebase):
+    rootdir = pathlib.Path(__file__).resolve().parent.parent
+    hpxmlfilename = str(rootdir / 'examples' / f'{filebase}.xml')
+    tree = objectify.parse(hpxmlfilename)
+    root = tree.getroot()
+    ns = re.match(r'\{(.+)\}', root.tag).group(1)
+    E = objectify.ElementMaker(
+        annotate=False,
+        namespace=ns
+    )
+    return tree, E
+
+
+def scrub_hpxml_doc(doc):
+    f_in = io.BytesIO()
+    doc.write(f_in)
+    f_in.seek(0)
+    tr = HPXMLtoHEScoreTranslator(f_in)
+    f_out = io.BytesIO()
+    tr.export_scrubbed_hpxml(f_out)
+    f_out.seek(0)
+    scrubbed_doc = objectify.parse(f_out)
+    return scrubbed_doc
+
+
+def test_remove_customer():
+    doc, E = get_example_xml_tree_elementmaker('hescore_min_v3')
+    hpxml = doc.getroot()
+    hpxml.Building.addprevious(
+        E.Customer(
+            E.CustomerDetails(
+                E.Person(
+                    E.SystemIdentifier(
+                        E.SendingSystemIdentifierType('some other id'),
+                        E.SendingSystemIdentifierValue('1234'),
+                        id='customer1'
+                    ),
+                    E.Name(
+                        E.FirstName('John'),
+                        E.LastName('Doe')
+                    ),
+                    E.Telephone(
+                        E.TelephoneNumber('555-555-5555')
+                    )
+                ),
+                E.MailingAddress(
+                    E.Address1('PO Box 1234'),
+                    E.CityMunicipality('Anywhere'),
+                    E.StateCode('CO')
+                )
+            ),
+            E.Comments(
+                E.Comment('personal things to say go here')
+            )
+        )
+    )
+    doc2 = scrub_hpxml_doc(doc)
+    hpxml2 = doc2.getroot()
+    assert len(hpxml2.Customer) == 1
+    assert len(hpxml2.Customer.getchildren()) == 1
+    assert len(hpxml2.Customer.CustomerDetails.getchildren()) == 1
+    assert len(hpxml2.Customer.CustomerDetails.Person.getchildren()) == 1
+    assert hpxml2.Customer.CustomerDetails.Person.SystemIdentifier.attrib['id'] == 'customer1'

--- a/tests/test_scrub.py
+++ b/tests/test_scrub.py
@@ -84,6 +84,7 @@ def test_remove_health_and_safety(hpxml_filebase):
     )
     doc2 = scrub_hpxml_doc(doc)
     assert len(doc2.xpath('//h:HealthAndSafety', namespaces={'h': hpxml.nsmap[None]})) == 0
+    assert False
 
 
 @pytest.mark.parametrize('hpxml_filebase', both_hescore_min)

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -109,14 +109,25 @@ class TestCLI(unittest.TestCase, ComparatorBase):
 
     def test_cli_pass(self):
         xml_file_path = os.path.abspath(os.path.join(thisdir, '..', 'examples', 'hescore_min.xml'))
-        tmpdir = tempfile.mkdtemp()
-        outfile = os.path.join(tmpdir, 'hescore_min.json')
-        main([xml_file_path, '-o', outfile])
-        with open(outfile, 'r') as f:
-            d1 = json.load(f)
-        with open(xml_file_path.replace('.xml', '.json'), 'r') as f:
-            d2 = json.load(f)
-        self._compare_item(d1, d2)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outfile = os.path.join(tmpdir, 'hescore_min.json')
+            main([xml_file_path, '-o', outfile])
+            with open(outfile, 'r') as f:
+                d1 = json.load(f)
+            with open(xml_file_path.replace('.xml', '.json'), 'r') as f:
+                d2 = json.load(f)
+            self._compare_item(d1, d2)
+
+    def test_cli_scrubbed(self):
+        root_dir = os.path.abspath(os.path.join(thisdir, '..'))
+        xml_file_path = os.path.join(root_dir, 'examples', 'hescore_min_v3.xml')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outfile = os.path.join(tmpdir, 'out.xml')
+            main([xml_file_path, '--scrubbed-hpxml', outfile])
+            schema_doc = etree.parse(os.path.join(root_dir, 'hescorehpxml', 'schemas', 'hpxml-3.0.0', 'HPXML.xsd'))
+            schema = etree.XMLSchema(schema_doc.getroot())
+            parser = etree.XMLParser(schema=schema)
+            etree.parse(outfile, parser)
 
 
 class TestOtherHouses(unittest.TestCase, ComparatorBase):

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -131,8 +131,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Window/h:Orientation[text()="south"]')
         el.text = 'west'
         self.assertRaisesRegex(TranslationError,
-                                r'The house has windows on shared walls\.',
-                                tr.hpxml_to_hescore)
+                               r'The house has windows on shared walls\.',
+                               tr.hpxml_to_hescore)
 
     def test_townhouse_walls_all_same(self):
         tr = self._load_xmlfile('townhouse_walls')
@@ -160,8 +160,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Window/h:Orientation[text()="south"]')
         el.text = 'west'
         self.assertRaisesRegex(TranslationError,
-                                r'The house has windows on shared walls\.',
-                                tr.hpxml_to_hescore)
+                               r'The house has windows on shared walls\.',
+                               tr.hpxml_to_hescore)
 
     def test_townhouse_walls_conflict(self):
         tr = self._load_xmlfile('townhouse_walls')
@@ -207,28 +207,28 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.getparent().remove(siding)
         self.assertRaisesRegex(TranslationError,
-                                r'Exterior finish information is missing',
-                                tr.hpxml_to_hescore)
+                               r'Exterior finish information is missing',
+                               tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.getparent().remove(siding)
         self.assertRaisesRegex(TranslationError,
-                                r'Exterior finish information is missing',
-                                tr_v3.hpxml_to_hescore)
+                               r'Exterior finish information is missing',
+                               tr_v3.hpxml_to_hescore)
 
     def test_siding_fail2(self):
         tr = self._load_xmlfile('hescore_min')
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.text = 'other'
         self.assertRaisesRegex(TranslationError,
-                                r'There is no HEScore wall siding equivalent for the HPXML option: other',
-                                tr.hpxml_to_hescore)
+                               r'There is no HEScore wall siding equivalent for the HPXML option: other',
+                               tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.text = 'other'
         self.assertRaisesRegex(TranslationError,
-                                r'There is no HEScore wall siding equivalent for the HPXML option: other',
-                                tr_v3.hpxml_to_hescore)
+                               r'There is no HEScore wall siding equivalent for the HPXML option: other',
+                               tr_v3.hpxml_to_hescore)
 
     def test_siding_cmu_fail(self):
         tr = self._load_xmlfile('hescore_min')
@@ -263,54 +263,54 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el.clear()
         etree.SubElement(el, tr.addns('h:LogWall'))
         self.assertRaisesRegex(TranslationError,
-                                r'Wall type LogWall not supported',
-                                tr.hpxml_to_hescore)
+                               r'Wall type LogWall not supported',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Wall[1]/h:WallType')
         el.clear()
         etree.SubElement(el, tr_v3.addns('h:LogWall'))
         self.assertRaisesRegex(TranslationError,
-                                r'Wall type LogWall not supported',
-                                tr_v3.hpxml_to_hescore)
+                               r'Wall type LogWall not supported',
+                               tr_v3.hpxml_to_hescore)
 
     def test_missing_residential_facility_type(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ResidentialFacilityType')
         el.getparent().remove(el)
         self.assertRaisesRegex(TranslationError,
-                                r'ResidentialFacilityType is required in the HPXML document',
-                                tr.hpxml_to_hescore)
+                               r'ResidentialFacilityType is required in the HPXML document',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:ResidentialFacilityType')
         el.getparent().remove(el)
         self.assertRaisesRegex(TranslationError,
-                                r'ResidentialFacilityType is required in the HPXML document',
-                                tr_v3.hpxml_to_hescore)
+                               r'ResidentialFacilityType is required in the HPXML document',
+                               tr_v3.hpxml_to_hescore)
 
     def test_invalid_residential_faciliy_type(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ResidentialFacilityType')
         el.text = 'manufactured home'
         self.assertRaisesRegex(TranslationError,
-                                r'Cannot translate HPXML ResidentialFacilityType of .+ into HEScore building shape',
-                                tr.hpxml_to_hescore)
+                               r'Cannot translate HPXML ResidentialFacilityType of .+ into HEScore building shape',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:ResidentialFacilityType')
         el.text = 'manufactured home'
         self.assertRaisesRegex(TranslationError,
-                                r'Cannot translate HPXML ResidentialFacilityType of .+ into HEScore building shape',
-                                tr_v3.hpxml_to_hescore)
+                               r'Cannot translate HPXML ResidentialFacilityType of .+ into HEScore building shape',
+                               tr_v3.hpxml_to_hescore)
 
     def test_missing_surroundings(self):
         tr = self._load_xmlfile('townhouse_walls')
         el = self.xpath('//h:Surroundings')
         el.getparent().remove(el)
         self.assertRaisesRegex(TranslationError,
-                                r'Site/Surroundings element is required in the HPXML document for town houses',
-                                tr.hpxml_to_hescore)
+                               r'Site/Surroundings element is required in the HPXML document for town houses',
+                               tr.hpxml_to_hescore)
 
     def test_invalid_surroundings(self):
         tr = self._load_xmlfile('townhouse_walls')
@@ -326,16 +326,16 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Attic[1]/h:AttachedToRoof')
         el.getparent().remove(el)
         self.assertRaisesRegex(TranslationError,
-                                r'Attic .+ does not have a roof associated with it\.',
-                                tr.hpxml_to_hescore)
+                               r'Attic .+ does not have a roof associated with it\.',
+                               tr.hpxml_to_hescore)
 
     def test_invalid_attic_type(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Attic[1]/h:AtticType')
         el.text = 'other'
         self.assertRaisesRegex(TranslationError,
-                                'Attic .+ Cannot translate HPXML AtticType .+ to HEScore rooftype.',
-                                tr.hpxml_to_hescore)
+                               'Attic .+ Cannot translate HPXML AtticType .+ to HEScore rooftype.',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Attics/h:Attic[1]/h:AtticType/h:Attic/h:Vented')
@@ -343,8 +343,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         etree.SubElement(attic_type_el, tr_v3.addns('h:Other'))
         attic_type_el.remove(el.getparent())
         self.assertRaisesRegex(TranslationError,
-                                'Attic .+ Cannot translate HPXML AtticType to HEScore rooftype.',
-                                tr_v3.hpxml_to_hescore)
+                               'Attic .+ Cannot translate HPXML AtticType to HEScore rooftype.',
+                               tr_v3.hpxml_to_hescore)
 
     def test_missing_roof_color(self):
         tr = self._load_xmlfile('hescore_min')
@@ -364,45 +364,45 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.text = 'no one major type'
         self.assertRaisesRegex(TranslationError,
-                                'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
-                                tr.hpxml_to_hescore)
+                               'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.text = 'no one major type'
         self.assertRaisesRegex(TranslationError,
-                                'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
-                                tr_v3.hpxml_to_hescore)
+                               'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
+                               tr_v3.hpxml_to_hescore)
 
     def test_missing_roof_type(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.getparent().remove(el)
         self.assertRaisesRegex(TranslationError,
-                                'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
-                                tr.hpxml_to_hescore)
+                               'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.getparent().remove(el)
         self.assertRaisesRegex(TranslationError,
-                                'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
-                                tr_v3.hpxml_to_hescore)
+                               'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
+                               tr_v3.hpxml_to_hescore)
 
     def test_missing_skylight_area(self):
         tr = self._load_xmlfile('hescore_min')
         area = self.xpath('//h:Skylight[1]/h:Area')
         area.getparent().remove(area)
         self.assertRaisesRegex(TranslationError,
-                                r'Every skylight needs an area\.',
-                                tr.hpxml_to_hescore)
+                               r'Every skylight needs an area\.',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         area = self.xpath('//h:Skylight[1]/h:Area')
         area.getparent().remove(area)
         self.assertRaisesRegex(TranslationError,
-                                r'Every skylight needs an area\.',
-                                tr_v3.hpxml_to_hescore)
+                               r'Every skylight needs an area\.',
+                               tr_v3.hpxml_to_hescore)
 
     def test_foundation_walls_on_slab(self):
         tr = self._load_xmlfile('house7')
@@ -414,8 +414,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         etree.SubElement(fndwall, tr.addns('h:SystemIdentifier'), attrib={'id': 'asdfjkl12345'})
         fnd.insert(i, fndwall)
         self.assertRaisesRegex(TranslationError,
-                                r'The house is a slab on grade foundation, but has foundation walls\.',
-                                tr.hpxml_to_hescore)
+                               r'The house is a slab on grade foundation, but has foundation walls\.',
+                               tr.hpxml_to_hescore)
 
     def test_slab_missing(self):
         tr = self._load_xmlfile('house3')
@@ -492,8 +492,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Window[h:GlassLayers="single-pane"]/h:FrameType/h:Aluminum')
         etree.SubElement(el, tr.addns('h:ThermalBreak')).text = "true"
         self.assertRaisesRegex(TranslationError,
-                                'There is no compatible HEScore window type for',
-                                tr.hpxml_to_hescore)
+                               'There is no compatible HEScore window type for',
+                               tr.hpxml_to_hescore)
 
     def test_impossible_triple_pane_window(self):
         tr = self._load_xmlfile('hescore_min')
@@ -506,8 +506,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         etree.SubElement(window, tr.addns('h:GlassType')).text = 'low-e'
         etree.SubElement(window, tr.addns('h:GasFill')).text = 'argon'
         self.assertRaisesRegex(TranslationError,
-                                'There is no compatible HEScore window type for',
-                                tr.hpxml_to_hescore)
+                               'There is no compatible HEScore window type for',
+                               tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         frame_type = self.xpath('//h:Window[h:SystemIdentifier/@id="window4"]/h:FrameType')
         frame_type.clear()
@@ -518,8 +518,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         etree.SubElement(window, tr_v3.addns('h:GlassType')).text = 'low-e'
         etree.SubElement(window, tr_v3.addns('h:GasFill')).text = 'argon'
         self.assertRaisesRegex(TranslationError,
-                                'There is no compatible HEScore window type for',
-                                tr_v3.hpxml_to_hescore)
+                               'There is no compatible HEScore window type for',
+                               tr_v3.hpxml_to_hescore)
 
     def test_impossible_heating_system_type(self):
         tr = self._load_xmlfile('hescore_min')
@@ -527,31 +527,31 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el.clear()
         etree.SubElement(el, tr.addns('h:PortableHeater'))
         self.assertRaisesRegex(TranslationError,
-                                'HEScore does not support the HPXML HeatingSystemType',
-                                tr.hpxml_to_hescore)
+                               'HEScore does not support the HPXML HeatingSystemType',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:HeatingSystem[1]/h:HeatingSystemType')
         el.clear()
         etree.SubElement(el, tr_v3.addns('h:PortableHeater'))
         self.assertRaisesRegex(TranslationError,
-                                'HEScore does not support the HPXML HeatingSystemType',
-                                tr_v3.hpxml_to_hescore)
+                               'HEScore does not support the HPXML HeatingSystemType',
+                               tr_v3.hpxml_to_hescore)
 
     def test_impossible_cooling_system_type(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:CoolingSystem[1]/h:CoolingSystemType')
         el.text = 'other'
         self.assertRaisesRegex(TranslationError,
-                                'HEScore does not support the HPXML CoolingSystemType',
-                                tr.hpxml_to_hescore)
+                               'HEScore does not support the HPXML CoolingSystemType',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:CoolingSystem[1]/h:CoolingSystemType')
         el.text = 'other'
         self.assertRaisesRegex(TranslationError,
-                                'HEScore does not support the HPXML CoolingSystemType',
-                                tr_v3.hpxml_to_hescore)
+                               'HEScore does not support the HPXML CoolingSystemType',
+                               tr_v3.hpxml_to_hescore)
 
     def test_evap_cooling_system_type(self):
         tr = self._load_xmlfile('hescore_min')
@@ -598,49 +598,49 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:DuctLocation[1]')
         el.text = 'unconditioned basement'
         self.assertRaisesRegex(TranslationError,
-                                'HVAC distribution: duct1 location: uncond_basement not exists in zone_roof/floor',
-                                tr.hpxml_to_hescore)
+                               'HVAC distribution: duct1 location: uncond_basement not exists in zone_roof/floor',
+                               tr.hpxml_to_hescore)
 
         el.text = 'interstitial space'
         self.assertRaisesRegex(TranslationError,
-                                'No comparable duct location in HEScore: interstitial space',
-                                tr.hpxml_to_hescore)
+                               'No comparable duct location in HEScore: interstitial space',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:DuctLocation[1]')
         el.text = 'basement - unconditioned'
         self.assertRaisesRegex(TranslationError,
-                                'HVAC distribution: duct1 location: uncond_basement not exists in zone_roof/floor',
-                                tr_v3.hpxml_to_hescore)
+                               'HVAC distribution: duct1 location: uncond_basement not exists in zone_roof/floor',
+                               tr_v3.hpxml_to_hescore)
 
         el.text = 'interstitial space'
         self.assertRaisesRegex(TranslationError,
-                                'No comparable duct location in HEScore: interstitial space',
-                                tr_v3.hpxml_to_hescore)
+                               'No comparable duct location in HEScore: interstitial space',
+                               tr_v3.hpxml_to_hescore)
 
     def test_missing_water_heater(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:WaterHeating')
         el.getparent().remove(el)
         self.assertRaisesRegex(TranslationError,
-                                r'No water heating systems found\.',
-                                tr.hpxml_to_hescore)
+                               r'No water heating systems found\.',
+                               tr.hpxml_to_hescore)
 
     def test_indirect_dhw_error(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:WaterHeatingSystem[1]/h:WaterHeaterType')
         el.text = 'space-heating boiler with storage tank'
         self.assertRaisesRegex(TranslationError,
-                                'Cannot have water heater type indirect if there is no boiler heating system',
-                                tr.hpxml_to_hescore)
+                               'Cannot have water heater type indirect if there is no boiler heating system',
+                               tr.hpxml_to_hescore)
 
     def test_tankless_coil_dhw_error(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:WaterHeatingSystem[1]/h:WaterHeaterType')
         el.text = 'space-heating boiler with tankless coil'
         self.assertRaisesRegex(TranslationError,
-                                'Cannot have water heater type tankless_coil if there is no boiler heating system',
-                                tr.hpxml_to_hescore)
+                               'Cannot have water heater type tankless_coil if there is no boiler heating system',
+                               tr.hpxml_to_hescore)
 
     def test_missing_attached_to_roof(self):
         self._load_xmlfile('hescore_min')
@@ -670,8 +670,8 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         htgsys = self._wood_stove_setup()
         htgsys.find(self.translator.addns('h:HeatingSystemFuel')).text = 'natural gas'
         self.assertRaisesRegex(TranslationError,
-                                r'Heating system wood_stove cannot be used with fuel natural_gas',
-                                self.translator.hpxml_to_hescore)
+                               r'Heating system wood_stove cannot be used with fuel natural_gas',
+                               self.translator.hpxml_to_hescore)
 
     def test_too_many_duct_systems(self):
         tr = self._load_xmlfile('house5')
@@ -689,32 +689,32 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         dist_sys_el = self.xpath('//h:HeatingSystem[h:SystemIdentifier/@id="backfurnace"]/h:DistributionSystem')
         dist_sys_el.set('idref', 'frontducts')
         self.assertRaisesRegex(TranslationError,
-                                r'Each duct system is only allowed to serve one heating and one cooling system',
-                                tr.hpxml_to_hescore)
+                               r'Each duct system is only allowed to serve one heating and one cooling system',
+                               tr.hpxml_to_hescore)
 
     def test_dist_sys_idref(self):
         tr = self._load_xmlfile('house5')
         dist_sys_el = self.xpath('//h:HeatingSystem[h:SystemIdentifier/@id="backfurnace"]/h:DistributionSystem')
         dist_sys_el.set('idref', 'backwindows1')
         self.assertRaisesRegex(TranslationError,
-                                r'HVAC plant .+ specifies an HPXML distribution system of .+, which does not exist.',
-                                tr.hpxml_to_hescore)
+                               r'HVAC plant .+ specifies an HPXML distribution system of .+, which does not exist.',
+                               tr.hpxml_to_hescore)
 
     def test_htg_sys_has_air_dist(self):
         tr = self._load_xmlfile('hescore_min')
         dist_sys_el = self.xpath('//h:HeatingSystem[1]/h:DistributionSystem')
         dist_sys_el.getparent().remove(dist_sys_el)
         self.assertRaisesRegex(TranslationError,
-                                r'Heating system .+ is not associated with an air distribution system\.',
-                                tr.hpxml_to_hescore)
+                               r'Heating system .+ is not associated with an air distribution system\.',
+                               tr.hpxml_to_hescore)
 
     def test_clg_sys_has_air_dist(self):
         tr = self._load_xmlfile('hescore_min')
         dist_sys_el = self.xpath('//h:CoolingSystem[1]/h:DistributionSystem')
         dist_sys_el.getparent().remove(dist_sys_el)
         self.assertRaisesRegex(TranslationError,
-                                r'Cooling system .+ is not associated with an air distribution system\.',
-                                tr.hpxml_to_hescore)
+                               r'Cooling system .+ is not associated with an air distribution system\.',
+                               tr.hpxml_to_hescore)
 
     def test_floor_no_area(self):
         tr = self._load_xmlfile('house8')
@@ -1114,72 +1114,72 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Building/h:ProjectStatus/h:Date')
         el.text = '2009-12-31'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'assessment_date is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'assessment_date is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_assessment_date2(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Building/h:ProjectStatus/h:Date')
         el.text = (dt.datetime.today().date() + dt.timedelta(1)).isoformat()
         self.assertRaisesRegex(InputOutOfBounds,
-                                'assessment_date is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'assessment_date is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_year_built1(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:YearBuilt')
         el.text = '1599'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'year_built is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'year_built is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_year_built2(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:YearBuilt')
         el.text = str(dt.datetime.today().year + 1)
         self.assertRaisesRegex(InputOutOfBounds,
-                                'year_built is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'year_built is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_num_floor_above_grade(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:NumberofConditionedFloorsAboveGrade')
         el.text = '5'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'num_floor_above_grade is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'num_floor_above_grade is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_floor_to_ceiling_height1(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:AverageCeilingHeight')
         el.text = '5'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'floor_to_ceiling_height is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'floor_to_ceiling_height is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_floor_to_ceiling_height2(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:AverageCeilingHeight')
         el.text = '13'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'floor_to_ceiling_height is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'floor_to_ceiling_height is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_conditioned_floor_area1(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ConditionedFloorArea')
         el.text = '249'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'conditioned_floor_area is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'conditioned_floor_area is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_conditioned_floor_area2(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ConditionedFloorArea')
         el.text = '25001'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'conditioned_floor_area is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'conditioned_floor_area is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_envelope_leakage(self):
         tr = self._load_xmlfile('hescore_min')
@@ -1188,16 +1188,16 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         units_el.text = 'CFM'
         leak_el.text = '25001'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'envelope_leakage is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'envelope_leakage is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_skylight_area(self):
         tr = self._load_xmlfile('house4')
         el = self.xpath('//h:Skylight/h:Area')
         el.text = '301'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'skylight_area is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'skylight_area is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_skylight_u_value(self):
         tr = self._load_xmlfile('house4')
@@ -1205,65 +1205,65 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         etree.SubElement(skylight, tr.addns('h:UFactor')).text = '0.001'
         etree.SubElement(skylight, tr.addns('h:SHGC')).text = '0.7'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'skylight_u_value is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'skylight_u_value is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_window_area(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Window[1]/h:Area')
         el.text = '1000'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'window_area is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'window_area is out of bounds',
+                               tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Window[1]/h:Area')
         el.text = '1000'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'window_area is out of bounds',
-                                tr_v3.hpxml_to_hescore)
+                               'window_area is out of bounds',
+                               tr_v3.hpxml_to_hescore)
 
     def test_window_u_value(self):
         tr = self._load_xmlfile('house2')
         el = self.xpath('//h:Window[1]/h:UFactor')
         el.text = '5.00001'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'window_u_value is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'window_u_value is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_heating_efficiency_furnace(self):
         tr = self._load_xmlfile('hescore_min')
         htg_eff_el = self.xpath('//h:HeatingSystem/h:AnnualHeatingEfficiency/h:Value')
         htg_eff_el.text = '1.01'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
         htg_eff_el.text = '0.59'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         htg_eff_el = self.xpath('//h:HeatingSystem/h:AnnualHeatingEfficiency/h:Value')
         htg_eff_el.text = '1.01'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr_v3.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr_v3.hpxml_to_hescore)
         htg_eff_el.text = '0.59'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr_v3.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr_v3.hpxml_to_hescore)
 
     def test_heating_efficiency_heat_pump(self):
         tr = self._load_xmlfile('house4')
         htg_eff_el = self.xpath('//h:HeatPump/h:AnnualHeatEfficiency/h:Value')
         htg_eff_el.text = '5.9'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
         htg_eff_el.text = '20.1'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_heating_efficiency_gchp(self):
         tr = self._load_xmlfile('house3')
@@ -1274,32 +1274,32 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         eff_value_el = etree.SubElement(eff_el, tr.addns('h:Value'))
         eff_value_el.text = '1.9'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
         eff_value_el.text = '5.1'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'heating_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_heating_year(self):
         tr = self._load_xmlfile('house3')
         el = self.xpath('//h:HeatPump/h:YearInstalled')
         el.text = str(dt.datetime.today().year + 1)
         self.assertRaisesRegex(InputOutOfBounds,
-                                'heating_year is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'heating_year is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_cooling_efficiency(self):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:CoolingSystem/h:AnnualCoolingEfficiency/h:Value')
         el.text = '40.1'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'cooling_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'cooling_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
         el.text = '7.9'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'cooling_efficiency is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'cooling_efficiency is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_evap_cooler_missing_efficiency(self):
         tr = self._load_xmlfile('hescore_min')
@@ -1319,20 +1319,20 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         year_el = self.xpath('//h:CoolingSystem/h:YearInstalled')
         year_el.text = str(dt.datetime.today().year + 1)
         self.assertRaisesRegex(InputOutOfBounds,
-                                'cooling_year is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'cooling_year is out of bounds',
+                               tr.hpxml_to_hescore)
 
     def test_dhw_storage_efficiency(self):
         tr = self._load_xmlfile('house1')
         el = self.xpath('//h:WaterHeatingSystem/h:EnergyFactor')
         el.text = '0.44'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'domestic_hot_water_energy_factor is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'domestic_hot_water_energy_factor is out of bounds',
+                               tr.hpxml_to_hescore)
         el.text = '1.1'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'domestic_hot_water_energy_factor is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'domestic_hot_water_energy_factor is out of bounds',
+                               tr.hpxml_to_hescore)
         el.text = '1.0'
         res = tr.hpxml_to_hescore()
         dhw = res['building']['systems']['domestic_hot_water']
@@ -1349,12 +1349,12 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         ef_el = etree.SubElement(dhw_sys_el, tr.addns('h:EnergyFactor'))
         ef_el.text = '0.9'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'domestic_hot_water_energy_factor is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'domestic_hot_water_energy_factor is out of bounds',
+                               tr.hpxml_to_hescore)
         ef_el.text = '4.1'
         self.assertRaisesRegex(InputOutOfBounds,
-                                'domestic_hot_water_energy_factor is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'domestic_hot_water_energy_factor is out of bounds',
+                               tr.hpxml_to_hescore)
         ef_el.text = '4.0'
         res = tr.hpxml_to_hescore()
         dhw = res['building']['systems']['domestic_hot_water']
@@ -1366,8 +1366,8 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:WaterHeatingSystem/h:YearInstalled')
         el.text = str(dt.datetime.today().year + 1)
         self.assertRaisesRegex(InputOutOfBounds,
-                                'domestic_hot_water_year is out of bounds',
-                                tr.hpxml_to_hescore)
+                               'domestic_hot_water_year is out of bounds',
+                               tr.hpxml_to_hescore)
 
 
 class TestHVACFractions(unittest.TestCase, ComparatorBase):
@@ -2177,8 +2177,8 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         # If no hvac system existing, should give a error message describing the problem.
         clg_sys.getparent().remove(clg_sys)
         self.assertRaisesRegex(TranslationError,
-                                'No hvac system found.',
-                                tr.hpxml_to_hescore)
+                               'No hvac system found.',
+                               tr.hpxml_to_hescore)
 
     def test_bldg_about_comment(self):
         tr = self._load_xmlfile('house4')
@@ -2223,14 +2223,14 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         duct3oc1.text = 'conditioned space'  # set back to cond_space to avoid previous error message
         rooftype.text = 'flat roof'  # change attic type
         self.assertRaisesRegex(TranslationError,
-                                'HVAC distribution: duct2 location: uncond_attic not exists in zone_roof/floor types.',
-                                tr.hpxml_to_hescore)
+                               'HVAC distribution: duct2 location: uncond_attic not exists in zone_roof/floor types.',
+                               tr.hpxml_to_hescore)
 
         rooftype.text = 'vented attic'  # set back to vented_attic to avoid previous error message
         Crawtype.text = 'false'
         self.assertRaisesRegex(TranslationError,
-                                'HVAC distribution: duct1 location: vented_crawl not exists in zone_roof/floor types.',
-                                tr.hpxml_to_hescore)
+                               'HVAC distribution: duct1 location: vented_crawl not exists in zone_roof/floor types.',
+                               tr.hpxml_to_hescore)
 
     def test_tankless_energyfactorerror(self):
         tr = self._load_xmlfile('hescore_min')

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -130,7 +130,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('townhouse_walls')
         el = self.xpath('//h:Window/h:Orientation[text()="south"]')
         el.text = 'west'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'The house has windows on shared walls\.',
                                 tr.hpxml_to_hescore)
 
@@ -159,7 +159,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         # This means that the interpreter should assume all walls are like the first wall.
         el = self.xpath('//h:Window/h:Orientation[text()="south"]')
         el.text = 'west'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'The house has windows on shared walls\.',
                                 tr.hpxml_to_hescore)
 
@@ -168,7 +168,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         # move a wall to the west (attached) side
         el = self.xpath('//h:Wall[1]/h:Orientation')
         el.text = 'west'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'The house has walls defined for sides ((front|right|left|back)(, )?)+ and shared walls on sides ((front|right|left|back)(, )?)+',  # noqa: E501
             tr.hpxml_to_hescore
@@ -206,13 +206,13 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.getparent().remove(siding)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Exterior finish information is missing',
                                 tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.getparent().remove(siding)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Exterior finish information is missing',
                                 tr_v3.hpxml_to_hescore)
 
@@ -220,13 +220,13 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.text = 'other'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'There is no HEScore wall siding equivalent for the HPXML option: other',
                                 tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         siding = self.xpath('//h:Wall[1]/h:Siding')
         siding.text = 'other'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'There is no HEScore wall siding equivalent for the HPXML option: other',
                                 tr_v3.hpxml_to_hescore)
 
@@ -239,7 +239,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         siding.text = 'vinyl siding'
         rvalue = self.xpath('//h:Wall[1]/h:Insulation/h:Layer[1]/h:NominalRValue')
         rvalue.text = '3'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'is a CMU and needs a siding of stucco, brick, or none to translate to HEScore. It has a siding type of vinyl siding',  # noqa: E501
             tr.hpxml_to_hescore)
@@ -252,7 +252,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         siding.text = 'vinyl siding'
         rvalue = self.xpath('//h:Wall[1]/h:Insulation/h:Layer[1]/h:NominalRValue')
         rvalue.text = '3'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'is a CMU and needs a siding of stucco, brick, or none to translate to HEScore. It has a siding type of vinyl siding',  # noqa: E501
             tr_v3.hpxml_to_hescore)
@@ -262,7 +262,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Wall[1]/h:WallType')
         el.clear()
         etree.SubElement(el, tr.addns('h:LogWall'))
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Wall type LogWall not supported',
                                 tr.hpxml_to_hescore)
 
@@ -270,7 +270,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:Wall[1]/h:WallType')
         el.clear()
         etree.SubElement(el, tr_v3.addns('h:LogWall'))
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Wall type LogWall not supported',
                                 tr_v3.hpxml_to_hescore)
 
@@ -278,14 +278,14 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ResidentialFacilityType')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'ResidentialFacilityType is required in the HPXML document',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:ResidentialFacilityType')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'ResidentialFacilityType is required in the HPXML document',
                                 tr_v3.hpxml_to_hescore)
 
@@ -293,14 +293,14 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ResidentialFacilityType')
         el.text = 'manufactured home'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Cannot translate HPXML ResidentialFacilityType of .+ into HEScore building shape',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:ResidentialFacilityType')
         el.text = 'manufactured home'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Cannot translate HPXML ResidentialFacilityType of .+ into HEScore building shape',
                                 tr_v3.hpxml_to_hescore)
 
@@ -308,7 +308,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('townhouse_walls')
         el = self.xpath('//h:Surroundings')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Site/Surroundings element is required in the HPXML document for town houses',
                                 tr.hpxml_to_hescore)
 
@@ -316,7 +316,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('townhouse_walls')
         el = self.xpath('//h:Surroundings')
         el.text = 'attached on three sides'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Cannot translate HPXML Site/Surroundings element value of .+ into HEScore town_house_walls',
             tr.hpxml_to_hescore)
@@ -325,7 +325,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house6')
         el = self.xpath('//h:Attic[1]/h:AttachedToRoof')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Attic .+ does not have a roof associated with it\.',
                                 tr.hpxml_to_hescore)
 
@@ -333,7 +333,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Attic[1]/h:AtticType')
         el.text = 'other'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Attic .+ Cannot translate HPXML AtticType .+ to HEScore rooftype.',
                                 tr.hpxml_to_hescore)
 
@@ -342,7 +342,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         attic_type_el = el.getparent().getparent()
         etree.SubElement(attic_type_el, tr_v3.addns('h:Other'))
         attic_type_el.remove(el.getparent())
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Attic .+ Cannot translate HPXML AtticType to HEScore rooftype.',
                                 tr_v3.hpxml_to_hescore)
 
@@ -363,14 +363,14 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.text = 'no one major type'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.text = 'no one major type'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
                                 tr_v3.hpxml_to_hescore)
 
@@ -378,14 +378,14 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Roof[1]/h:RoofType')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Attic .+ HEScore does not have an analogy to the HPXML roof type: .+',
                                 tr_v3.hpxml_to_hescore)
 
@@ -393,14 +393,14 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         area = self.xpath('//h:Skylight[1]/h:Area')
         area.getparent().remove(area)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Every skylight needs an area\.',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         area = self.xpath('//h:Skylight[1]/h:Area')
         area.getparent().remove(area)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Every skylight needs an area\.',
                                 tr_v3.hpxml_to_hescore)
 
@@ -413,7 +413,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         fndwall = etree.Element(tr.addns('h:FoundationWall'))
         etree.SubElement(fndwall, tr.addns('h:SystemIdentifier'), attrib={'id': 'asdfjkl12345'})
         fnd.insert(i, fndwall)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'The house is a slab on grade foundation, but has foundation walls\.',
                                 tr.hpxml_to_hescore)
 
@@ -443,7 +443,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Window[1]/h:Orientation')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Window\[SystemIdentifier/@id="\w+"\] doesn\'t have Azimuth, Orientation, or AttachedToWall. At least one is required.',  # noqa E501
             tr.hpxml_to_hescore)
@@ -451,7 +451,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Window[1]/h:Orientation')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Window\[SystemIdentifier/@id="\w+"\] doesn\'t have Azimuth, Orientation, or AttachedToWall. At least one is required.',  # noqa E501
             tr_v3.hpxml_to_hescore)
@@ -464,7 +464,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         self._do_compare('house4')
 
         window.remove(window_orientation)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'The Window\[SystemIdentifier/@id="\w+"\] has no Azimuth or Orientation, and the .* didn\'t reference a Wall element.',  # noqa E501
             tr.hpxml_to_hescore
@@ -491,7 +491,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house1')
         el = self.xpath('//h:Window[h:GlassLayers="single-pane"]/h:FrameType/h:Aluminum')
         etree.SubElement(el, tr.addns('h:ThermalBreak')).text = "true"
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'There is no compatible HEScore window type for',
                                 tr.hpxml_to_hescore)
 
@@ -505,7 +505,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         glass_layers.text = 'triple-pane'
         etree.SubElement(window, tr.addns('h:GlassType')).text = 'low-e'
         etree.SubElement(window, tr.addns('h:GasFill')).text = 'argon'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'There is no compatible HEScore window type for',
                                 tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
@@ -517,7 +517,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         glass_layers.text = 'triple-pane'
         etree.SubElement(window, tr_v3.addns('h:GlassType')).text = 'low-e'
         etree.SubElement(window, tr_v3.addns('h:GasFill')).text = 'argon'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'There is no compatible HEScore window type for',
                                 tr_v3.hpxml_to_hescore)
 
@@ -526,7 +526,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:HeatingSystem[1]/h:HeatingSystemType')
         el.clear()
         etree.SubElement(el, tr.addns('h:PortableHeater'))
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HEScore does not support the HPXML HeatingSystemType',
                                 tr.hpxml_to_hescore)
 
@@ -534,7 +534,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el = self.xpath('//h:HeatingSystem[1]/h:HeatingSystemType')
         el.clear()
         etree.SubElement(el, tr_v3.addns('h:PortableHeater'))
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HEScore does not support the HPXML HeatingSystemType',
                                 tr_v3.hpxml_to_hescore)
 
@@ -542,14 +542,14 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:CoolingSystem[1]/h:CoolingSystemType')
         el.text = 'other'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HEScore does not support the HPXML CoolingSystemType',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:CoolingSystem[1]/h:CoolingSystemType')
         el.text = 'other'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HEScore does not support the HPXML CoolingSystemType',
                                 tr_v3.hpxml_to_hescore)
 
@@ -579,7 +579,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el.getparent().remove(el)
         el = self.xpath('//h:HeatPump[1]/h:FloorAreaServed')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Every heating/cooling system needs to have either FloorAreaServed or FracHeatLoadServed/FracCoolLoadServed',  # noqa E501
                                 tr.hpxml_to_hescore)
 
@@ -589,7 +589,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         el.getparent().remove(el)
         el = self.xpath('//h:CoolingSystem[2]/h:FloorAreaServed')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Every heating/cooling system needs to have either FloorAreaServed or FracHeatLoadServed/FracCoolLoadServed',  # noqa E501
                                 tr.hpxml_to_hescore)
 
@@ -597,24 +597,24 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:DuctLocation[1]')
         el.text = 'unconditioned basement'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HVAC distribution: duct1 location: uncond_basement not exists in zone_roof/floor',
                                 tr.hpxml_to_hescore)
 
         el.text = 'interstitial space'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'No comparable duct location in HEScore: interstitial space',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:DuctLocation[1]')
         el.text = 'basement - unconditioned'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HVAC distribution: duct1 location: uncond_basement not exists in zone_roof/floor',
                                 tr_v3.hpxml_to_hescore)
 
         el.text = 'interstitial space'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'No comparable duct location in HEScore: interstitial space',
                                 tr_v3.hpxml_to_hescore)
 
@@ -622,7 +622,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:WaterHeating')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'No water heating systems found\.',
                                 tr.hpxml_to_hescore)
 
@@ -630,7 +630,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:WaterHeatingSystem[1]/h:WaterHeaterType')
         el.text = 'space-heating boiler with storage tank'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Cannot have water heater type indirect if there is no boiler heating system',
                                 tr.hpxml_to_hescore)
 
@@ -638,7 +638,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:WaterHeatingSystem[1]/h:WaterHeaterType')
         el.text = 'space-heating boiler with tankless coil'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'Cannot have water heater type tankless_coil if there is no boiler heating system',
                                 tr.hpxml_to_hescore)
 
@@ -669,7 +669,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
     def test_wood_stove_invalid_fuel_type(self):
         htgsys = self._wood_stove_setup()
         htgsys.find(self.translator.addns('h:HeatingSystemFuel')).text = 'natural gas'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Heating system wood_stove cannot be used with fuel natural_gas',
                                 self.translator.hpxml_to_hescore)
 
@@ -679,7 +679,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         htg_sys = dist_sys_el.getparent()
         idx = htg_sys.index(dist_sys_el)
         htg_sys.insert(idx, etree.Element(tr.addns('h:DistributionSystem'), idref='frontducts'))
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Each HVAC plant is only allowed to specify one duct system\. .+ references more than one',
             tr.hpxml_to_hescore)
@@ -688,7 +688,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house5')
         dist_sys_el = self.xpath('//h:HeatingSystem[h:SystemIdentifier/@id="backfurnace"]/h:DistributionSystem')
         dist_sys_el.set('idref', 'frontducts')
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Each duct system is only allowed to serve one heating and one cooling system',
                                 tr.hpxml_to_hescore)
 
@@ -696,7 +696,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house5')
         dist_sys_el = self.xpath('//h:HeatingSystem[h:SystemIdentifier/@id="backfurnace"]/h:DistributionSystem')
         dist_sys_el.set('idref', 'backwindows1')
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'HVAC plant .+ specifies an HPXML distribution system of .+, which does not exist.',
                                 tr.hpxml_to_hescore)
 
@@ -704,7 +704,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         dist_sys_el = self.xpath('//h:HeatingSystem[1]/h:DistributionSystem')
         dist_sys_el.getparent().remove(dist_sys_el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Heating system .+ is not associated with an air distribution system\.',
                                 tr.hpxml_to_hescore)
 
@@ -712,7 +712,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         dist_sys_el = self.xpath('//h:CoolingSystem[1]/h:DistributionSystem')
         dist_sys_el.getparent().remove(dist_sys_el)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 r'Cooling system .+ is not associated with an air distribution system\.',
                                 tr.hpxml_to_hescore)
 
@@ -720,7 +720,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house8')
         el = self.xpath('//h:Foundation[1]/*/h:Area')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'If there is more than one foundation, each needs an area specified on either "Slab" or "FrameFloor" '
             r'attached',
@@ -764,7 +764,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house7')
         el = self.xpath('//h:CoolingSystem[h:SystemIdentifier/@id="roomac"]/h:AnnualCoolingEfficiency/h:Units')
         el.text = 'SEER'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Cooling efficiency could not be determined',
             tr.hpxml_to_hescore
@@ -777,7 +777,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:HeatingSystem/h:AnnualHeatingEfficiency/h:Units')
         el.text = 'Percent'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Heating efficiency could not be determined',
             tr.hpxml_to_hescore
@@ -832,7 +832,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house3')
         el = self.xpath('//h:Wall[1]/h:Insulation/h:Layer[1]/h:NominalRValue')
         el.getparent().remove(el)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Every wall insulation layer needs a NominalRValue',
             tr.hpxml_to_hescore
@@ -962,7 +962,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         wood_stud_wall_type = self.xpath('//h:Wall[1]/h:WallType/h:WoodStud')
         etree.SubElement(wood_stud_wall_type, tr.addns('h:OptimumValueEngineering')).text = 'true'
         self.xpath('//h:Wall[1]/h:Insulation/h:Layer[h:InstallationType="cavity"]/h:NominalRValue').text = '0'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Wall R-value outside HEScore bounds',
             tr.hpxml_to_hescore
@@ -1027,7 +1027,7 @@ class TestOtherHouses(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house4')
         el = self.xpath('//h:HeatPump[h:SystemIdentifier/@id="heatpump1"]/h:HeatPumpType')
         el.text = 'air-to-air'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'(Cooling|Heating) system heatpump1 is not associated with an air distribution system',
             tr.hpxml_to_hescore
@@ -1113,7 +1113,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Building/h:ProjectStatus/h:Date')
         el.text = '2009-12-31'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'assessment_date is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1121,7 +1121,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Building/h:ProjectStatus/h:Date')
         el.text = (dt.datetime.today().date() + dt.timedelta(1)).isoformat()
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'assessment_date is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1129,7 +1129,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:YearBuilt')
         el.text = '1599'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'year_built is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1137,7 +1137,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:YearBuilt')
         el.text = str(dt.datetime.today().year + 1)
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'year_built is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1145,7 +1145,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:NumberofConditionedFloorsAboveGrade')
         el.text = '5'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'num_floor_above_grade is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1153,7 +1153,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:AverageCeilingHeight')
         el.text = '5'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'floor_to_ceiling_height is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1161,7 +1161,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:AverageCeilingHeight')
         el.text = '13'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'floor_to_ceiling_height is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1169,7 +1169,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ConditionedFloorArea')
         el.text = '249'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'conditioned_floor_area is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1177,7 +1177,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:ConditionedFloorArea')
         el.text = '25001'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'conditioned_floor_area is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1187,7 +1187,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         leak_el = self.xpath('//h:BuildingAirLeakage/h:AirLeakage')
         units_el.text = 'CFM'
         leak_el.text = '25001'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'envelope_leakage is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1195,7 +1195,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house4')
         el = self.xpath('//h:Skylight/h:Area')
         el.text = '301'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'skylight_area is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1204,7 +1204,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         skylight = self.xpath('//h:Skylight')
         etree.SubElement(skylight, tr.addns('h:UFactor')).text = '0.001'
         etree.SubElement(skylight, tr.addns('h:SHGC')).text = '0.7'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'skylight_u_value is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1212,13 +1212,13 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:Window[1]/h:Area')
         el.text = '1000'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'window_area is out of bounds',
                                 tr.hpxml_to_hescore)
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         el = self.xpath('//h:Window[1]/h:Area')
         el.text = '1000'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'window_area is out of bounds',
                                 tr_v3.hpxml_to_hescore)
 
@@ -1226,7 +1226,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house2')
         el = self.xpath('//h:Window[1]/h:UFactor')
         el.text = '5.00001'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'window_u_value is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1234,22 +1234,22 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         htg_eff_el = self.xpath('//h:HeatingSystem/h:AnnualHeatingEfficiency/h:Value')
         htg_eff_el.text = '1.01'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
         htg_eff_el.text = '0.59'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
 
         tr_v3 = self._load_xmlfile('hescore_min_v3')
         htg_eff_el = self.xpath('//h:HeatingSystem/h:AnnualHeatingEfficiency/h:Value')
         htg_eff_el.text = '1.01'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr_v3.hpxml_to_hescore)
         htg_eff_el.text = '0.59'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr_v3.hpxml_to_hescore)
 
@@ -1257,11 +1257,11 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house4')
         htg_eff_el = self.xpath('//h:HeatPump/h:AnnualHeatEfficiency/h:Value')
         htg_eff_el.text = '5.9'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
         htg_eff_el.text = '20.1'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1273,11 +1273,11 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         etree.SubElement(eff_el, tr.addns('h:Units')).text = 'COP'
         eff_value_el = etree.SubElement(eff_el, tr.addns('h:Value'))
         eff_value_el.text = '1.9'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
         eff_value_el.text = '5.1'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1285,7 +1285,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house3')
         el = self.xpath('//h:HeatPump/h:YearInstalled')
         el.text = str(dt.datetime.today().year + 1)
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'heating_year is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1293,11 +1293,11 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:CoolingSystem/h:AnnualCoolingEfficiency/h:Value')
         el.text = '40.1'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'cooling_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
         el.text = '7.9'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'cooling_efficiency is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1318,7 +1318,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         eff_el.getparent().remove(eff_el)
         year_el = self.xpath('//h:CoolingSystem/h:YearInstalled')
         year_el.text = str(dt.datetime.today().year + 1)
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'cooling_year is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1326,11 +1326,11 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('house1')
         el = self.xpath('//h:WaterHeatingSystem/h:EnergyFactor')
         el.text = '0.44'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'domestic_hot_water_energy_factor is out of bounds',
                                 tr.hpxml_to_hescore)
         el.text = '1.1'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'domestic_hot_water_energy_factor is out of bounds',
                                 tr.hpxml_to_hescore)
         el.text = '1.0'
@@ -1348,11 +1348,11 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         dhw_sys_el = self.xpath('//h:WaterHeatingSystem')
         ef_el = etree.SubElement(dhw_sys_el, tr.addns('h:EnergyFactor'))
         ef_el.text = '0.9'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'domestic_hot_water_energy_factor is out of bounds',
                                 tr.hpxml_to_hescore)
         ef_el.text = '4.1'
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'domestic_hot_water_energy_factor is out of bounds',
                                 tr.hpxml_to_hescore)
         ef_el.text = '4.0'
@@ -1365,7 +1365,7 @@ class TestInputOutOfBounds(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         el = self.xpath('//h:WaterHeatingSystem/h:YearInstalled')
         el.text = str(dt.datetime.today().year + 1)
-        self.assertRaisesRegexp(InputOutOfBounds,
+        self.assertRaisesRegex(InputOutOfBounds,
                                 'domestic_hot_water_year is out of bounds',
                                 tr.hpxml_to_hescore)
 
@@ -1650,7 +1650,7 @@ class TestPhotovoltaics(unittest.TestCase, ComparatorBase):
     def test_capacity_missing(self):
         tr = self._load_xmlfile('hescore_min')
         self._add_pv(capacity=None)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'MaxPowerOutput or CollectorArea is required',
             tr.hpxml_to_hescore
@@ -1675,7 +1675,7 @@ class TestPhotovoltaics(unittest.TestCase, ComparatorBase):
     def test_azimuth_orientation_missing(self):
         tr = self._load_xmlfile('hescore_min')
         self._add_pv(azimuth=None, orientation=None)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'ArrayAzimuth or ArrayOrientation is required for every PVSystem',
             tr.hpxml_to_hescore
@@ -1684,7 +1684,7 @@ class TestPhotovoltaics(unittest.TestCase, ComparatorBase):
     def test_years_missing(self):
         tr = self._load_xmlfile('hescore_min')
         self._add_pv(module_year=None, inverter_year=None)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Either YearInverterManufactured or YearModulesManufactured is required for every PVSystem',
             tr.hpxml_to_hescore
@@ -1711,7 +1711,7 @@ class TestPhotovoltaics(unittest.TestCase, ComparatorBase):
             orientation='west',
             inverter_year=None,
             module_year=2013)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Either a MaxPowerOutput must be specified for every PVSystem or CollectorArea',
             tr.hpxml_to_hescore
@@ -2010,7 +2010,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
                 if j != i and heat_pump_type_map[htg_hp_type] != heat_pump_type_map[clg_hp_type]:
                     hp2_type = tr.xpath(hp2, 'h:HeatPumpType')
                     hp2_type.text = clg_hp_type
-                    self.assertRaisesRegexp(
+                    self.assertRaisesRegex(
                         TranslationError,
                         r'Two different heat pump systems: .+ for heating, and .+ for cooling are not supported in one hvac system.',  # noqa: E501
                         tr.hpxml_to_hescore)
@@ -2176,7 +2176,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         # Red area: No system.
         # If no hvac system existing, should give a error message describing the problem.
         clg_sys.getparent().remove(clg_sys)
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'No hvac system found.',
                                 tr.hpxml_to_hescore)
 
@@ -2209,26 +2209,26 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         duct3oc1.text = 'unvented crawlspace'
         rooftype = self.xpath('//h:Attic[h:SystemIdentifier/@id="attic1"]/h:AtticType')
         Crawtype = self.xpath('//h:Foundation[h:SystemIdentifier/@id="crawl1"]/h:FoundationType/h:Crawlspace/h:Vented')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             'HVAC distribution: duct3 location: unvented_crawl not exists in zone_roof/floor types.',
             tr.hpxml_to_hescore)
 
         duct3oc1.text = 'unconditioned basement'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             'HVAC distribution: duct3 location: uncond_basement not exists in zone_roof/floor types.',
             tr.hpxml_to_hescore)
 
         duct3oc1.text = 'conditioned space'  # set back to cond_space to avoid previous error message
         rooftype.text = 'flat roof'  # change attic type
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HVAC distribution: duct2 location: uncond_attic not exists in zone_roof/floor types.',
                                 tr.hpxml_to_hescore)
 
         rooftype.text = 'vented attic'  # set back to vented_attic to avoid previous error message
         Crawtype.text = 'false'
-        self.assertRaisesRegexp(TranslationError,
+        self.assertRaisesRegex(TranslationError,
                                 'HVAC distribution: duct1 location: vented_crawl not exists in zone_roof/floor types.',
                                 tr.hpxml_to_hescore)
 
@@ -2236,7 +2236,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         tr = self._load_xmlfile('hescore_min')
         WHtype = self.xpath('//h:WaterHeatingSystem[h:SystemIdentifier/@id="dhw1"]/h:WaterHeaterType')
         WHtype.text = 'instantaneous water heater'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Tankless water heater efficiency cannot be estimated by shipment weighted method\.',
             tr.hpxml_to_hescore)
@@ -2282,7 +2282,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         attic = self.xpath('//h:Attic[h:SystemIdentifier/@id="attic1"]')
         attic_type = self.xpath('//h:Attic[h:SystemIdentifier/@id="attic1"]/h:AtticType')
         attic_type.text = 'other'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Attic attic1: Cannot translate HPXML AtticType other to HEScore rooftype.',
             tr.hpxml_to_hescore
@@ -2293,7 +2293,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         roof_type = d['building']['zone']['zone_roof'][0]['roof_type']
         self.assertEqual(roof_type, 'cond_attic')
         is_attic_cond.text = 'false'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Attic \w+: Cannot translate HPXML AtticType other to HEScore rooftype.',
             tr.hpxml_to_hescore
@@ -2460,7 +2460,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         )
         building_el.addnext(project_el)
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'The following elements are required.*StartDate.*CompleteDateActual.*BusinessName.*ZipCode',
             tr.hpxml_to_hescore
@@ -2575,7 +2575,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         heatpump_type = self.xpath('//h:HeatPump[h:SystemIdentifier/@id="heatpump1"]/h:HeatPumpType')
         heatpump_type.text = 'air-to-air'
         heatpump_type.addprevious(E.DistributionSystem(idref='hvacd1'))
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Two different heat pump systems: .+ for heating, and .+ for cooling are not supported in one hvac system.', # noqa E501
             tr.hpxml_to_hescore)
@@ -2647,7 +2647,7 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         heatpump_type = self.xpath('//h:HeatPump[h:SystemIdentifier/@id="heatpump1"]/h:HeatPumpType')
         heatpump_type.text = 'air-to-air'
         heatpump_type.addprevious(E.DistributionSystem(idref='hvacd1'))
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Two different heat pump systems: .+ for heating, and .+ for cooling are not supported in one hvac system.', # noqa E501
             tr_v3.hpxml_to_hescore)
@@ -2782,7 +2782,7 @@ class TestHEScoreV3(unittest.TestCase, ComparatorBase):
         heatpump_type = self.xpath('//h:HeatPump[h:SystemIdentifier/@id="heatpump1"]/h:HeatPumpType')
         heatpump_type.text = 'air-to-air'
         heatpump_type.addprevious(E.DistributionSystem(idref='hvacd1'))
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Two different heat pump systems: .+ for heating, and .+ for cooling are not supported in one hvac system.', # noqa E501
             tr.hpxml_to_hescore)
@@ -2825,7 +2825,7 @@ class TestHEScoreV3(unittest.TestCase, ComparatorBase):
         tr.xpath(roof2, 'h:Insulation/h:SystemIdentifier').attrib['id'] = "attic1roofins2"
         tr.xpath(frame_floor2, 'h:SystemIdentifier').attrib['id'] = "framefloor2"
         tr.xpath(frame_floor2, 'h:Insulation/h:SystemIdentifier').attrib['id'] = "attic1flrins2"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'If there are more than one Attic elements, each needs an area. '
             r'Please specify under its attached FrameFloor/Roof element.',
@@ -2837,7 +2837,7 @@ class TestHEScoreV3(unittest.TestCase, ComparatorBase):
         attached_to_ff2 = deepcopy(attached_to_ff)
         attached_to_ff2.attrib['idref'] = "framefloor2"
         attached_to_ff.addnext(attached_to_ff2)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'If there are more than one FrameFloor elements attached to attic, each needs an area.',
             tr.hpxml_to_hescore)
@@ -2848,7 +2848,7 @@ class TestHEScoreV3(unittest.TestCase, ComparatorBase):
         attached_to_roof2 = deepcopy(attached_to_roof)
         attached_to_roof2.attrib['idref'] = "roof2"
         attached_to_roof.addnext(attached_to_roof2)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'If there are more than one Roof elements attached to a single attic, each needs an area.',
             tr.hpxml_to_hescore)
@@ -2858,7 +2858,7 @@ class TestHEScoreV3(unittest.TestCase, ComparatorBase):
         # 0 roof, will error out during xpath execution
         attached_to_roof2.getparent().remove(attached_to_roof2)
         attached_to_roof.attrib['idref'] = 'no_roof'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TranslationError,
             r'Attic attic1 does not have a roof associated with it.',
             tr.hpxml_to_hescore)


### PR DESCRIPTION
Fixes #125.

This PR does the following:
- Adds a cli arg `--scrubbed-hpxml` to optionally export an HPXML file with PII removed.
- Switches the testing framework to pytest.
- Removes compatibility with Python 2.7. We were getting a lot of deprecation warnings in the testing. Python 2.7 [reached end of life on Jan 1, 2020](https://www.python.org/doc/sunset-python-2/), so it seems like this is an appropriate time to drop support. 