### PR TITLE
Skylight assignment

### DIFF
--- a/docs/source/translation/zone_window.rst
+++ b/docs/source/translation/zone_window.rst
@@ -36,7 +36,9 @@ window properties be assigned to each direction, the
 windows will be specified separately. 
 
 Skylights in HEScore do not have an orientation that can be set, therefore
-orientation/azimuth information about skylights is ignored.
+orientation/azimuth information about skylights is ignored. Use `AttachedToRoof`
+to specify which HPXML roof each skylight is attached to. If not specified, skylights
+will be assigned to the first hescore roof.
 
 .. _window-prop:
 

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -1283,7 +1283,7 @@ class HPXMLtoHEScoreTranslatorBase(object):
             skylight_by_roof_num[i] = []
 
         for skylight in skylights:
-            if xpath(skylight, 'h:AttachedToRoof/@idref')is None:
+            if xpath(skylight, 'h:AttachedToRoof/@idref') is None:
                 # No roof attached, attach to the first roof
                 skylight_by_roof_num[0].append(skylight)
             else:

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -1287,7 +1287,11 @@ class HPXMLtoHEScoreTranslatorBase(object):
                 # No roof attached, attach to the first roof
                 skylight_by_roof_num[0].append(skylight)
             else:
-                skylight_by_roof_id[xpath(skylight, 'h:AttachedToRoof/@idref')].append(skylight)
+                try:
+                    skylight_by_roof_id[xpath(skylight, 'h:AttachedToRoof/@idref')].append(skylight)
+                except KeyError:
+                    skylight_by_roof_id[xpath(skylight, 'h:AttachedToRoof/@idref')] = []
+                    skylight_by_roof_id[xpath(skylight, 'h:AttachedToRoof/@idref')].append(skylight)
 
         for roof_id, skylights in list(skylight_by_roof_id.items()):
             # roof_found = False

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -2669,6 +2669,45 @@ class TestHEScore2019Updates(unittest.TestCase, ComparatorBase):
         self.assertEqual(d_4['building']['systems']['hvac'], d_4_v3['building']['systems']['hvac'])
 
 
+class TestHEScore2021Updates(unittest.TestCase, ComparatorBase):
+
+    def test_skylight_assignment(self):
+        tr = self._load_xmlfile('house4_v3')
+        attach_roof = etree.Element(tr.addns('h:AttachedToRoof'))
+        attach_roof.attrib['idref'] = "roof2"
+        glass_type = self.xpath('//h:Skylight/h:GlassType')
+        glass_type.addnext(attach_roof)
+        res = tr.hpxml_to_hescore()
+        # Skylight attached to the second roof
+        self.assertEqual(res['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_area'], 12.0)
+        self.assertEqual(res['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_code'], 'dtab')
+        self.assertFalse(res['building']['zone']['zone_roof'][1]['zone_skylight']['solar_screen'])
+
+        skylight = self.xpath('//h:Skylight')
+        skylight_2 = deepcopy(skylight)
+        skylight.addnext(skylight_2)
+        tr.xpath(skylight_2, 'h:SystemIdentifier').attrib['id'] = "skylight2"
+        tr.xpath(skylight_2, 'h:AttachedToRoof').attrib['idref'] = "roof1"
+        tr.xpath(skylight_2, 'h:Area').text = "15"
+        res2 = tr.hpxml_to_hescore()
+        # Skylight attached to the first and second roof
+        self.assertEqual(res2['building']['zone']['zone_roof'][0]['zone_skylight']['skylight_area'], 15.0)
+        self.assertEqual(res2['building']['zone']['zone_roof'][0]['zone_skylight']['skylight_code'], 'dtab')
+        self.assertFalse(res2['building']['zone']['zone_roof'][0]['zone_skylight']['solar_screen'])
+        self.assertEqual(res2['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_area'], 12.0)
+        self.assertEqual(res2['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_code'], 'dtab')
+        self.assertFalse(res2['building']['zone']['zone_roof'][1]['zone_skylight']['solar_screen'])
+
+        tr.xpath(skylight_2, 'h:AttachedToRoof').attrib['idref'] = "roof2"
+        tr.xpath(skylight_2, 'h:Area').text = "10"
+        tr.xpath(skylight_2, 'h:GlassType').text = "low-e"
+        # skylight1 dominates the properties
+        res3 = tr.hpxml_to_hescore()
+        self.assertEqual(res3['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_area'], 22.0)
+        self.assertEqual(res3['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_code'], 'dtab')
+        self.assertFalse(res3['building']['zone']['zone_roof'][1]['zone_skylight']['solar_screen'])
+
+
 class TestHEScoreV3(unittest.TestCase, ComparatorBase):
 
     def test_attic_with_multiple_roofs(self):


### PR DESCRIPTION
Allow skylights to be assigned to the attached roofs if exist.
Fix #135 