### PR TITLE
Handle zip+4 in hpxml

### DIFF
--- a/docs/source/translation/building_address.rst
+++ b/docs/source/translation/building_address.rst
@@ -33,8 +33,10 @@ format for HEScore.
 
 HPXML allows for two lines of address elements. If both are used, the lines will
 be concatenated with a space between for submission to the HEScore
-``building_address.address`` field. All of the HPXML elements shown in the
-above code snippet are required with the exception of ``Address2``
+``building_address.address`` field. All of the HPXML elements shown in the above
+code snippet are required with the exception of ``Address2``. Additionally, if a
+zip plus 4 code is entered in HPXML, it will be trimmed to just the 5 digit zip
+code before being passed to HEScore.
 
 .. _assessment-type-mapping:
 

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -816,7 +816,8 @@ class HPXMLtoHEScoreTranslatorBase(object):
             raise ElementNotFoundError(hpxmladdress, 'h:Address1/text() | h:Address2/text()', {})
         bldgaddr['city'] = xpath(b, 'h:Site/h:Address/h:CityMunicipality/text()', raise_err=True)
         bldgaddr['state'] = xpath(b, 'h:Site/h:Address/h:StateCode/text()', raise_err=True)
-        bldgaddr['zip_code'] = xpath(b, 'h:Site/h:Address/h:ZipCode/text()', raise_err=True)
+        hpxml_zipcode = xpath(b, 'h:Site/h:Address/h:ZipCode/text()', raise_err=True)
+        bldgaddr['zip_code'] = re.match(r"([0-9]{5})(-[0-9]{4})?", hpxml_zipcode).group(1)
         transaction_type = xpath(self.hpxmldoc, 'h:XMLTransactionHeaderInformation/h:Transaction/text()')
         is_mentor = xpath(b, 'boolean(h:ProjectStatus/h:extension/h:HEScoreMentorAssessment)')
         if is_mentor:

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -3048,6 +3048,14 @@ class TestHEScore2021Updates(unittest.TestCase, ComparatorBase):
         self.assertEqual(res3['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_code'], 'dtab')
         self.assertFalse(res3['building']['zone']['zone_roof'][1]['zone_skylight']['solar_screen'])
 
+    def test_zip_plus4(self):
+        tr = self._load_xmlfile('hescore_min_v3')
+        el = self.xpath('//h:ZipCode')
+        orig_zipcode = str(el.text)
+        el.text = el.text + '-1234'
+        res = tr.hpxml_to_hescore()
+        self.assertEqual(res['building_address']['zip_code'], orig_zipcode)
+
 
 class TestHEScoreV3(unittest.TestCase, ComparatorBase):
 


### PR DESCRIPTION
Fixes #165

## Pull Request Description

Previously this just passed whatever was in the `ZipCode` element in HPXML to HEScore. The HPXML element can include a zip plus 4 code. This strips it to just pass the 5 digit zip code.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] Code changes (must work)
- [x] Test exercising your feature or bug fix. Check the coverage report in the build artifacts.
- [x] All other unit tests passing
- [x] Update translation docs