### PR TITLE
not allowing R-value to go past zero for walls with XPS

### DIFF
--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -262,7 +262,7 @@ class HPXMLtoHEScoreTranslatorBase(object):
                         tobool(xpath(hpxmlwall, 'h:WallType/h:WoodStud/h:ExpandedPolystyreneSheathing/text()')):
                     wallconstype = 'ps'
                     # account for the rigid foam sheathing in the construction code
-                    wall_rvalue -= 5
+                    wall_rvalue = max(0, wall_rvalue - 5)
                     rvalue = wall_round_to_nearest(wall_rvalue, (0, 3, 7, 11, 13, 15, 19, 21))
                 elif tobool(xpath(hpxmlwall, 'h:WallType/h:WoodStud/h:OptimumValueEngineering/text()')):
                     wallconstype = 'ov'

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -3051,6 +3051,17 @@ class TestHEScore2021Updates(unittest.TestCase, ComparatorBase):
         self.assertEqual(res3['building']['zone']['zone_roof'][1]['zone_skylight']['skylight_code'], 'dtab')
         self.assertFalse(res3['building']['zone']['zone_roof'][1]['zone_skylight']['solar_screen'])
 
+    def test_xps_negative(self):
+        tr = self._load_xmlfile('hescore_min_v3')
+        wall = self.xpath('//h:Wall[h:SystemIdentifier/@id="wall1"]')
+        tr.xpath(wall, 'h:Insulation/h:Layer/h:NominalRValue').text = "0"
+        wood_stud = tr.xpath(wall, 'descendant::h:WoodStud')
+        xps_el = etree.Element(tr.addns('h:ExpandedPolystyreneSheathing'))
+        xps_el.text = 'true'
+        wood_stud.append(xps_el)
+        res = tr.hpxml_to_hescore()
+        self.assertEqual(res['building']['zone']['zone_wall'][0]['wall_assembly_code'], 'ewps00br')
+
 
 class TestHEScoreV3(unittest.TestCase, ComparatorBase):
 


### PR DESCRIPTION
Fixes #148

## Pull Request Description

There was kind of a strange edge case where a wall could get a negative R-value if you specified XPS sheathing. This fixes that.

This branches off and will merge back into #160 because all the changes would conflict otherwise.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] Code changes (must work)
- [x] Test exercising your feature or bug fix. Check the coverage report in the build artifacts.
- [x] All other unit tests passing
- [x] ~~Update translation docs~~