### PR TITLE
Additional duct locations

### DIFF
--- a/docs/source/translation/hvac_distribution.rst
+++ b/docs/source/translation/hvac_distribution.rst
@@ -32,7 +32,7 @@ following mapping.
    unconditioned attic     uncond_attic
    interstitial space      *not translated*
    garage                  vented_crawl
-   outside                 *not translated*
+   outside                 outside
    ======================  ================
 
 .. table:: Duct Location mapping (HPXML v3)

--- a/docs/source/translation/hvac_distribution.rst
+++ b/docs/source/translation/hvac_distribution.rst
@@ -42,7 +42,7 @@ following mapping.
    ===========================  ================
    living space                 cond_space
    unconditioned space          uncond_basement, vented_crawl, unvented_crawl, uncond_attic
-   under slab                   vented_crawl
+   under slab                   under_slab
    basement                     uncond_basement, cond_space
    basement - unconditioned     uncond_basement
    basement - conditioned       cond_space
@@ -51,7 +51,7 @@ following mapping.
    crawlspace - unconditioned   vented_crawl, unvented_crawl
    crawlspace - conditioned     cond_space
    crawlspace                   vented_crawl, unvented_crawl, cond_space
-   exterior wall                *not translated*
+   exterior wall                exterior_wall
    attic                        uncond_attic, cond_space
    attic - unconditioned        uncond_attic
    attic - conditioned          cond_space
@@ -61,8 +61,8 @@ following mapping.
    garage                       vented_crawl
    garage - conditioned         cond_space
    garage - unconditioned       vented_crawl
-   roof deck                    vented_crawl
-   outside                      vented_crawl
+   roof deck                    outside
+   outside                      outside
    ===========================  ================
 
 .. warning:: 

--- a/hescorehpxml/hpxml2.py
+++ b/hescorehpxml/hpxml2.py
@@ -121,4 +121,4 @@ class HPXML2toHEScoreTranslator(HPXMLtoHEScoreTranslatorBase):
                          'unconditioned attic': 'uncond_attic',
                          'interstitial space': None,
                          'garage': 'vented_crawl',
-                         'outside': None}
+                         'outside': 'outside'}

--- a/hescorehpxml/hpxml3.py
+++ b/hescorehpxml/hpxml3.py
@@ -201,10 +201,9 @@ class HPXML3toHEScoreTranslator(HPXMLtoHEScoreTranslatorBase):
         # 'validate_hescore_inputs' error checking
         return loc_hierarchy[0]
 
-    # Please review the new location mapping.
     duct_location_map = {'living space': ['cond_space'],
                          'unconditioned space': ['uncond_basement', 'vented_crawl', 'unvented_crawl', 'uncond_attic'],
-                         'under slab': ['vented_crawl'],
+                         'under slab': ['under_slab'],
                          'basement': ['uncond_basement', 'cond_space'],
                          'basement - unconditioned': ['uncond_basement'],
                          'basement - conditioned': ['cond_space'],
@@ -213,13 +212,13 @@ class HPXML3toHEScoreTranslator(HPXMLtoHEScoreTranslatorBase):
                          'crawlspace - unconditioned': ['vented_crawl', 'unvented_crawl'],
                          'crawlspace - conditioned': ['cond_space'],
                          'crawlspace': ['vented_crawl', 'unvented_crawl', 'cond_space'],
-                         'exterior wall': None,
+                         'exterior wall': ['exterior_wall'],
                          'interstitial space': None,
                          'garage - conditioned': ['cond_space'],
                          'garage - unconditioned': ['unvented_crawl'],
                          'garage': ['unvented_crawl'],
-                         'roof deck': ['vented_crawl'],
-                         'outside': ['vented_crawl'],
+                         'roof deck': ['outside'],
+                         'outside': ['outside'],
                          'attic': ['uncond_attic', 'cond_space'],
                          'attic - unconditioned': ['uncond_attic'],
                          'attic - conditioned': ['cond_space'],

--- a/hescorehpxml/schemas/hescore_json.schema.json
+++ b/hescorehpxml/schemas/hescore_json.schema.json
@@ -1667,7 +1667,7 @@
                                                 },
                                                 "location": {
                                                     "type": "string",
-                                                    "enum": ["cond_space", "uncond_basement", "unvented_crawl", "vented_crawl", "uncond_attic"],
+                                                    "enum": ["cond_space", "uncond_basement", "unvented_crawl", "vented_crawl", "uncond_attic", "under_slab", "exterior_wall", "outside"],
                                                     "description": "Location of distribution system"
                                                 },
                                                 "fraction": {

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1766,7 +1766,45 @@ class TestPhotovoltaics(unittest.TestCase, ComparatorBase):
             )
 
 
-class TesHPXMLVersion2Point3(unittest.TestCase, ComparatorBase):
+class TestDuctLocations(unittest.TestCase, ComparatorBase):
+    '''
+    These are tests related to allowing additional duct locations
+    '''
+
+    def _set_duct_location(self, location):
+        el = self.xpath('//h:Ducts/h:DuctLocation')[0]
+        el.text = location
+
+    def test_under_slab(self):
+        tr = self._load_xmlfile('house1_v3')
+        self._set_duct_location('under slab')
+        hesd = tr.hpxml_to_hescore()
+        duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
+        self.assertEqual(duct['location'], 'under_slab')
+
+    def test_exterior_wall(self):
+        tr = self._load_xmlfile('house1_v3')
+        self._set_duct_location('exterior wall')
+        hesd = tr.hpxml_to_hescore()
+        duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
+        self.assertEqual(duct['location'], 'exterior_wall')
+
+    def test_outside(self):
+        tr = self._load_xmlfile('house1_v3')
+        self._set_duct_location('outside')
+        hesd = tr.hpxml_to_hescore()
+        duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
+        self.assertEqual(duct['location'], 'outside')
+
+    def test_roof_deck(self):
+        tr = self._load_xmlfile('house1_v3')
+        self._set_duct_location('roof deck')
+        hesd = tr.hpxml_to_hescore()
+        duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
+        self.assertEqual(duct['location'], 'outside')
+
+
+class TestHPXMLVersion2Point3(unittest.TestCase, ComparatorBase):
 
     def test_floor_furnace(self):
         tr = self._load_xmlfile('hescore_min')

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1772,32 +1772,32 @@ class TestDuctLocations(unittest.TestCase, ComparatorBase):
     '''
 
     def _set_duct_location(self, location):
-        el = self.xpath('//h:Ducts/h:DuctLocation')[0]
+        el = self.xpath('//h:Ducts/h:DuctLocation')
         el.text = location
 
     def test_under_slab(self):
-        tr = self._load_xmlfile('house1_v3')
+        tr = self._load_xmlfile('house3_v3')
         self._set_duct_location('under slab')
         hesd = tr.hpxml_to_hescore()
         duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
         self.assertEqual(duct['location'], 'under_slab')
 
     def test_exterior_wall(self):
-        tr = self._load_xmlfile('house1_v3')
+        tr = self._load_xmlfile('house3_v3')
         self._set_duct_location('exterior wall')
         hesd = tr.hpxml_to_hescore()
         duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
         self.assertEqual(duct['location'], 'exterior_wall')
 
     def test_outside(self):
-        tr = self._load_xmlfile('house1_v3')
+        tr = self._load_xmlfile('house3_v3')
         self._set_duct_location('outside')
         hesd = tr.hpxml_to_hescore()
         duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
         self.assertEqual(duct['location'], 'outside')
 
     def test_roof_deck(self):
-        tr = self._load_xmlfile('house1_v3')
+        tr = self._load_xmlfile('house3_v3')
         self._set_duct_location('roof deck')
         hesd = tr.hpxml_to_hescore()
         duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1812,6 +1812,13 @@ class TestDuctLocations(unittest.TestCase, ComparatorBase):
         duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
         self.assertEqual(duct['location'], 'outside')
 
+    def test_outside_v2(self):
+        tr = self._load_xmlfile('house3')
+        self._set_duct_location('outside')
+        hesd = tr.hpxml_to_hescore()
+        duct = hesd['building']['systems']['hvac'][0]['hvac_distribution'][0]
+        self.assertEqual(duct['location'], 'outside')
+
     def test_roof_deck(self):
         tr = self._load_xmlfile('house3_v3')
         self._set_duct_location('roof deck')


### PR DESCRIPTION
Corresponding PR to https://github.com/NREL/OpenStudio-HEScore/pull/315, which allows additional duct locations.

For HPXML v3 files, the duct location map changes as follows:

HPXML | Previous HEScore Input | New HEScore Input
-- | -- | --
under slab | vented_crawl | under_slab
exterior wall | *not translated* | exterior_wall
roof deck | vented_crawl | outside
outside | vented_crawl | outside

For the three HPXML duct locations above that were previously mapped, this PR allows the building to no longer need a vented crawlspace foundation.

For HPXML v2 files, the duct location map changes as follows:

HPXML | Previous HEScore Input | New HEScore Input
-- | -- | --
outside | *not translated* | outside

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] Code changes (must work)
- [x] Test exercising your feature or bug fix. Check the coverage report in the build artifacts.
- [x] All other unit tests passing
- [x] Update translation docs