### PR TITLE
Updating garage duct location to unvented_crawl

### DIFF
--- a/docs/source/translation/hvac_distribution.rst
+++ b/docs/source/translation/hvac_distribution.rst
@@ -31,7 +31,7 @@ following mapping.
    crawlspace              *not translated*
    unconditioned attic     uncond_attic
    interstitial space      *not translated*
-   garage                  vented_crawl
+   garage                  unvented_crawl
    outside                 outside
    ======================  ================
 
@@ -58,9 +58,9 @@ following mapping.
    attic - unvented             uncond_attic
    attic - vented               uncond_attic
    interstitial space           *not translated*
-   garage                       vented_crawl
+   garage                       unvented_crawl
    garage - conditioned         cond_space
-   garage - unconditioned       vented_crawl
+   garage - unconditioned       unvented_crawl
    roof deck                    outside
    outside                      outside
    ===========================  ================

--- a/hescorehpxml/hpxml2.py
+++ b/hescorehpxml/hpxml2.py
@@ -182,5 +182,5 @@ class HPXML2toHEScoreTranslator(HPXMLtoHEScoreTranslatorBase):
                          'crawlspace': None,
                          'unconditioned attic': 'uncond_attic',
                          'interstitial space': None,
-                         'garage': 'vented_crawl',
+                         'garage': 'unvented_crawl',
                          'outside': 'outside'}

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -3533,6 +3533,20 @@ class TestHEScore2021Updates(unittest.TestCase, ComparatorBase):
         res = tr.hpxml_to_hescore()
         self.assertEqual(res['building_address']['zip_code'], orig_zipcode)
 
+    def test_hpxmlv2_garage_duct_location(self):
+        tr = self._load_xmlfile('hescore_min')
+        el = self.xpath('//h:DuctLocation[1]')
+        el.text = 'garage'
+        basement_el = self.xpath('//h:FoundationType[1]/h:Basement')
+        fnd_type_el = basement_el.getparent()
+        fnd_type_el.remove(basement_el)
+        etree.SubElement(fnd_type_el, tr.addns('h:Garage'))
+        d = tr.hpxml_to_hescore()
+        self.assertEqual(
+            d['building']['systems']['hvac'][0]['hvac_distribution']['duct'][0]['location'],
+            'unvented_crawl'
+        )
+
 
 class TestHEScoreV3(unittest.TestCase, ComparatorBase):
 


### PR DESCRIPTION
Fixes #196

## Pull Request Description

There was inconsistency between how HPXML v2 and v3 were handled with translating garages as foundation types and duct locations.All should be mapped to `unvented_crawl`, but it was mapping to `vented_crawl` in HPXML v2. Also, the docs incorrectly said it was being mapped to `vented_crawl` everywhere. This fixes all that.

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [x] Code changes (must work)
- [x] Test exercising your feature or bug fix. Check the coverage report in the build artifacts.
- [x] All other unit tests passing
- [x] Update translation docs

@torstenglidden @lirainer 
