### PR TITLE
checking if distribution system returned before attaching

### DIFF
--- a/examples/house7.xml
+++ b/examples/house7.xml
@@ -122,6 +122,7 @@
                     <HVACPlant>
                         <HeatingSystem>
                             <SystemIdentifier id="boiler"/>
+                            <DistributionSystem idref="hydronicdist1"/>
                             <HeatingSystemType>
                                 <Boiler/>
                             </HeatingSystemType>
@@ -141,6 +142,12 @@
                             </AnnualCoolingEfficiency>
                         </CoolingSystem>
                     </HVACPlant>
+                    <HVACDistribution>
+                        <SystemIdentifier id="hydronicdist1"/>
+                        <DistributionSystemType>
+                            <HydronicDistribution/>
+                        </DistributionSystemType>
+                    </HVACDistribution>
                 </HVAC>
                 <WaterHeating>
                     <WaterHeatingSystem>

--- a/examples/house7_v3.xml
+++ b/examples/house7_v3.xml
@@ -125,6 +125,7 @@
                     <HVACPlant>
                         <HeatingSystem>
                             <SystemIdentifier id="boiler"/>
+                            <DistributionSystem idref="hydronicdist1"/>
                             <HeatingSystemType>
                                 <Boiler/>
                             </HeatingSystemType>
@@ -144,6 +145,12 @@
                             </AnnualCoolingEfficiency>
                         </CoolingSystem>
                     </HVACPlant>
+                    <HVACDistribution>
+                        <SystemIdentifier id="hydronicdist1"/>
+                        <DistributionSystemType>
+                            <HydronicDistribution/>
+                        </DistributionSystemType>
+                    </HVACDistribution>
                 </HVAC>
                 <WaterHeating>
                     <WaterHeatingSystem>

--- a/hescorehpxml/base.py
+++ b/hescorehpxml/base.py
@@ -2350,7 +2350,7 @@ class HPXMLtoHEScoreTranslatorBase(object):
                 hvac_sys['cooling'] = cooling_systems[hvac_ids.clg_id]
             else:
                 hvac_sys['cooling'] = {'type': 'none'}
-            if hvac_ids.dist_id is not None:
+            if hvac_ids.dist_id is not None and distribution_systems[hvac_ids.dist_id] is not None:
                 hvac_sys['hvac_distribution'] = distribution_systems[hvac_ids.dist_id]
 
             # Added a error check for separate cooling and heating heat pump system

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -3583,6 +3583,26 @@ class TestHEScore2021Updates(unittest.TestCase, ComparatorBase):
             'unvented_crawl'
         )
 
+    def test_boiler_no_cooling_sys_v2(self):
+        tr = self._load_xmlfile('house7')
+        el = self.xpath('//h:CoolingSystem[1]')
+        el.getparent().remove(el)
+        d = tr.hpxml_to_hescore()
+        self.assertNotIn(
+            'hvac_distribution',
+            d['building']['systems']['hvac'][0]
+        )
+
+    def test_boiler_no_cooling_sys_v3(self):
+        tr = self._load_xmlfile('house7')
+        el = self.xpath('//h:CoolingSystem[1]')
+        el.getparent().remove(el)
+        d = tr.hpxml_to_hescore()
+        self.assertNotIn(
+            'hvac_distribution',
+            d['building']['systems']['hvac'][0]
+        )
+
 
 class TestHEScoreV3(unittest.TestCase, ComparatorBase):
 


### PR DESCRIPTION
## Pull Request Description

Fixes the issue where if there's a boiler, no cooling system, and a hydronic distribution system referenced we'd get an error. 

## Checklist

PR Author: Check these when they're done. Not all may apply. ~~strikethrough~~ and check any that do not apply. 

PR Reviewer: Verify each has been completed.

- [ ] Code changes (must work)
- [x] Test exercising your feature or bug fix. Check the coverage report in the build artifacts.
- [x] All other unit tests passing
- [ ] Update translation docs
